### PR TITLE
starpu: Distribute nodes over offset, and not over timestamps

### DIFF
--- a/starpu/data.cc
+++ b/starpu/data.cc
@@ -317,7 +317,7 @@ starpu_ddesc_t* create_and_distribute_data(int rank, int world, int mb, int nb, 
 
   int m = mb * mt;
   int n = nb * nt;
-  desc_init(ddesc, 1, mb, nb, mb*nb, m, n, 0, 0, m, n, p, q, rank, desc_id);
+  desc_init(ddesc, 1, mb, nb, mb*nb, m, n, 0, 0, m, n, 1, world, rank, desc_id);
  // desc_init(ddesc, 1, mb, 1, mb, mt*mb, 1, 0, 0, mt*mb, 1, world, 1, rank);
 
   size_t size = (size_t)(ddesc->llm) * (size_t)(ddesc->lln)


### PR DESCRIPTION
Otherwise for m nodes, only sqrt(m) nodes will work on a given timestamp,
and sqrt(m) other nodes will work on a further timestamp, and so on,
thus leading to very low parallelism with almost all task graphs.