### PR TITLE
starpu: Fix invalidating cached input

### DIFF
--- a/test_all.sh
+++ b/test_all.sh
@@ -144,6 +144,7 @@ if [[ $USE_STARPU -eq 1 ]]; then
             mpirun -np 1 ./starpu/main -steps $steps -type $t $k -core 2
             mpirun -np 4 ./starpu/main -steps $steps -type $t $k -p 1 -core 2
             mpirun -np 4 ./starpu/main -steps $steps -type $t $k -p 2 -core 2
+            mpirun -np 4 ./starpu/main -field 4 -steps $steps -type $t $k -p 2 -core 2
             mpirun -np 4 ./starpu/main -steps $steps -type $t $k -p 4 -core 2
             mpirun -np 1 ./starpu/main -steps $steps -type $t $k -and -steps $steps -type $t $k -core 2
             mpirun -np 4 ./starpu/main -steps 16 -width 8 -type $t $k -p 1 -core 2 -S


### PR DESCRIPTION
When we are not writing to data, we still have to take care whether we
have already received it, and then not prune the task.

Possibly introduced by #47. Checking for cached data is however way
cheaper than submitting all rdeps.