### PR TITLE
starpu: Fix core reservation

### DIFF
--- a/experiments/cori_comm/metg_starpu.sh
+++ b/experiments/cori_comm/metg_starpu.sh
@@ -6,10 +6,11 @@
 #SBATCH --time=02:00:00
 #SBATCH --mail-type=ALL
 
-export STARPU_RESERVE_NCPU=1
+cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
 
-total_cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
-cores=$(( $total_cores - 1 ))
+# Reserve one core for the MPI thread
+export STARPU_RESERVE_NCPU=1
+computation_cores=$(( $cores - 1 ))
 
 function launch {
     srun -n $1 -N $1 --cpus-per-task=$(( cores * 2 )) --cpu_bind none ../../starpu/main "${@:2}" -core $cores -p 1 -S
@@ -32,7 +33,7 @@ function sweep {
         for s in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18; do
             if [[ $rep -le $s ]]; then
                 local args
-                repeat args $3 -kernel compute_bound -iter $(( 1 << (26-s) )) -type $4 -output $5 -radix ${RADIX:-5} -steps ${STEPS:-1000} -width $(( $2 * cores )) -field 2
+                repeat args $3 -kernel compute_bound -iter $(( 1 << (26-s) )) -type $4 -output $5 -radix ${RADIX:-5} -steps ${STEPS:-1000} -width $(( $2 * computation_cores )) -field 2
                 $1 $2 "${args[@]}"
             fi
         done

--- a/experiments/cori_cores_per_rank/metg_starpu.sh
+++ b/experiments/cori_cores_per_rank/metg_starpu.sh
@@ -6,10 +6,11 @@
 #SBATCH --time=01:00:00
 #SBATCH --mail-type=ALL
 
-export STARPU_RESERVE_NCPU=1
+cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
 
-total_cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
-cores=$(( $total_cores - 1 ))
+# Reserve one core for the MPI thread
+export STARPU_RESERVE_NCPU=1
+computation_cores=$(( $cores - 1 ))
 
 function launch {
     cores_per_rank=$2
@@ -34,7 +35,7 @@ function sweep {
         for rep in 0 1 2 3 4; do
             if [[ $rep -le $s ]]; then
                 local args
-                repeat args $3 -kernel compute_bound -iter $(( 1 << (26-s) )) -type $4 -radix ${RADIX:-5} -steps ${STEPS:-1000} -width $(( $2 * cores )) -field 2
+                repeat args $3 -kernel compute_bound -iter $(( 1 << (26-s) )) -type $4 -radix ${RADIX:-5} -steps ${STEPS:-1000} -width $(( $2 * computation_cores )) -field 2
                 $1 $2 $5 "${args[@]}"
             fi
         done

--- a/experiments/cori_metg_compute/metg_starpu.sh
+++ b/experiments/cori_metg_compute/metg_starpu.sh
@@ -6,10 +6,11 @@
 #SBATCH --time=01:00:00
 #SBATCH --mail-type=ALL
 
-export STARPU_RESERVE_NCPU=1
+cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
 
-total_cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
-cores=$(( $total_cores - 1 ))
+# Reserve one core for the MPI thread
+export STARPU_RESERVE_NCPU=1
+computation_cores=$(( $cores - 1 ))
 
 function launch {
     srun -n $1 -N $1 --cpus-per-task=$(( cores * 2 )) --cpu_bind none ../../starpu/main "${@:2}" -core $cores -p 1 -S
@@ -32,7 +33,7 @@ function sweep {
         for rep in 0 1 2 3 4; do
             if [[ $rep -le $s ]]; then
                 local args
-                repeat args $3 -kernel compute_bound -iter $(( 1 << (26-s) )) -type $4 -radix ${RADIX:-5} -steps ${STEPS:-1000} -width $(( $2 * cores )) -field 2
+                repeat args $3 -kernel compute_bound -iter $(( 1 << (26-s) )) -type $4 -radix ${RADIX:-5} -steps ${STEPS:-1000} -width $(( $2 * computation_cores )) -field 2
                 $1 $2 "${args[@]}"
             fi
         done

--- a/experiments/cori_metg_memory/metg_starpu.sh
+++ b/experiments/cori_metg_memory/metg_starpu.sh
@@ -6,10 +6,11 @@
 #SBATCH --time=02:00:00
 #SBATCH --mail-type=ALL
 
-export STARPU_RESERVE_NCPU=1
+cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
 
-total_cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
-cores=$(( $total_cores - 1 ))
+# Reserve one core for the MPI thread
+export STARPU_RESERVE_NCPU=1
+computation_cores=$(( $cores - 1 ))
 
 function launch {
     srun -n $1 -N $1 --cpus-per-task=$(( cores * 2 )) --cpu_bind none ../../starpu/main "${@:2}" -core $cores -p 1 -S
@@ -32,7 +33,7 @@ function sweep {
         for rep in 0 1 2 3 4; do
             if [[ $rep -le $s ]]; then
                 local args
-                repeat args $3 -kernel memory_bound -iter $(( 1 << (16-s) )) -scratch $(( 16 * 1024 * 1024 )) -sample 8192 -type $4 -radix ${RADIX:-5} -steps ${STEPS:-8192} -width $(( $2 * cores )) -field 2
+                repeat args $3 -kernel memory_bound -iter $(( 1 << (16-s) )) -scratch $(( 16 * 1024 * 1024 )) -sample 8192 -type $4 -radix ${RADIX:-5} -steps ${STEPS:-8192} -width $(( $2 * computation_cores )) -field 2
                 $1 $2 "${args[@]}"
             fi
         done

--- a/experiments/cori_radix/metg_starpu.sh
+++ b/experiments/cori_radix/metg_starpu.sh
@@ -6,10 +6,11 @@
 #SBATCH --time=01:00:00
 #SBATCH --mail-type=ALL
 
-export STARPU_RESERVE_NCPU=1
+cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
 
-total_cores=$(( $(echo $SLURM_JOB_CPUS_PER_NODE | cut -d'(' -f 1) / 2 ))
-cores=$(( $total_cores - 1 ))
+# Reserve one core for the MPI thread
+export STARPU_RESERVE_NCPU=1
+computation_cores=$(( $cores - 1 ))
 
 function launch {
     srun -n $1 -N $1 --cpus-per-task=$(( cores * 2 )) --cpu_bind none ../../starpu/main "${@:2}" -core $cores -p 1 -S
@@ -32,7 +33,7 @@ function sweep {
         for rep in 0 1 2 3 4; do
             if [[ $rep -le $s ]]; then
                 local args
-                repeat args $3 -kernel compute_bound -iter $(( 1 << (26-s) )) -type $4 -radix $5 -steps ${STEPS:-1000} -width $(( $2 * cores )) -field 2
+                repeat args $3 -kernel compute_bound -iter $(( 1 << (26-s) )) -type $4 -radix $5 -steps ${STEPS:-1000} -width $(( $2 * computation_cores )) -field 2
                 $1 $2 "${args[@]}"
             fi
         done


### PR DESCRIPTION
With StarPU 1.3, STARPU_RESERVE_NCPU already subtracts the cpu from
confs->ncpus, so we should still pass $cores to the -core option, and only
subtract 1 to the width.