### PR TITLE
Report estimated transfer bytes and bandwidth

### DIFF
--- a/chapel/task_benchmark.chpl
+++ b/chapel/task_benchmark.chpl
@@ -64,7 +64,7 @@ proc main(args: [] string) {
   t.start();
   execute_task_graphs(graphs, task_result, task_ready, task_used);
   t.stop();
-  app_report_timing(app, t.elapsed());
+  app_report_timing(app, t.elapsed(), 0);
 }
 
 proc make_task_result(n_graphs, max_width, max_output_bytes) {

--- a/charm++/main.C
+++ b/charm++/main.C
@@ -77,7 +77,7 @@ void Main::finishedGraph() {
   CkPrintf("Time for last run: %e\n", end - start);
   if (numRunsDone > 1) totalTimeElapsed += (end - start);
   if (numRunsDone == numRuns + 1) {
-    app.report_timing(totalTimeElapsed / numRuns);
+    app.report_timing(totalTimeElapsed / numRuns, 0);
     CkExit();
   } else {
     sectionProxy.reset(new MulticastMsg());

--- a/core/core.cc
+++ b/core/core.cc
@@ -1124,6 +1124,16 @@ static long long count_bytes(const TaskGraph &g)
   return bytes;
 }
 
+static std::tuple<long, long> clamp(long start, long end, long min_value, long max_value) {
+  if (end < min_value) {
+    return std::tuple<long, long>(min_value, min_value - 1);
+  } else if (start > max_value) {
+    return std::tuple<long, long>(max_value, max_value - 1);
+  } else {
+    return std::tuple<long, long>(std::max(start, min_value), std::min(end, max_value));
+  }
+}
+
 void App::report_timing(double elapsed_seconds, long nodes) const
 {
   long long total_num_tasks = 0;
@@ -1147,26 +1157,35 @@ void App::report_timing(double elapsed_seconds, long nodes) const
     for (long t = 0; t < g.timesteps; ++t) {
       long offset = g.offset_at_timestep(t);
       long width = g.width_at_timestep(t);
+      long last_offset = g.offset_at_timestep(t-1);
+      long last_width = g.width_at_timestep(t-1);
       long dset = g.dependence_set_at_timestep(t);
 
       num_tasks += width;
 
       for (long p = offset; p < offset + width; ++p) {
         long point_node = 0;
-        long first_point = 0;
-        long last_point = 0;
+        long node_first = 0;
+        long node_last = -1;
         if (nodes > 0) {
-          long point_node = p*nodes/g.max_width;
-          long first_point = point_node * g.max_width / nodes;
-          long last_point = (point_node + 1) * g.max_width / nodes - 1;
+          point_node = p*nodes/g.max_width;
+          node_first = point_node * g.max_width / nodes;
+          node_last = (point_node + 1) * g.max_width / nodes - 1;
         }
 
         auto deps = g.dependencies(dset, p);
         for (auto dep : deps) {
-          num_deps += dep.second - dep.first + 1;
+          long dep_first, dep_last;
+          std::tie(dep_first, dep_last) = clamp(dep.first, dep.second, last_offset, last_offset + last_width - 1);
+          num_deps += dep_last - dep_first + 1;
           if (nodes > 0) {
-            long long local_points = std::max(dep.second, first_point) - std::min(dep.first, last_point - 1) + 1;
-            local_deps += std::max(local_points, 0ll);
+            long initial_first, initial_last, local_first, local_last, final_first, final_last;
+            std::tie(initial_first, initial_last) = clamp(dep_first, dep_last, 0, node_first - 1);
+            std::tie(local_first, local_last) = clamp(dep_first, dep_last, node_first, node_last);
+            std::tie(final_first, final_last) = clamp(dep_first, dep_last, node_last + 1, g.max_width - 1);
+            nonlocal_deps += initial_last - initial_first + 1;
+            local_deps += local_last - local_first + 1;
+            nonlocal_deps += final_last - final_first + 1;
           }
         }
       }
@@ -1187,7 +1206,7 @@ void App::report_timing(double elapsed_seconds, long nodes) const
   if (nodes > 0) {
     printf("  Local Dependencies %lld (estimated)\n", total_local_deps);
     printf("  Nonlocal Dependencies %lld (estimated)\n", total_nonlocal_deps);
-    printf("  Number of Nodes %ld (used to create estimate)\n", nodes);
+    printf("  Number of Nodes (used for estimate) %ld\n", nodes);
   } else {
     printf("  Unable to estimate local/nonlocal dependencies\n");
   }

--- a/core/core.cc
+++ b/core/core.cc
@@ -1184,7 +1184,9 @@ void App::report_timing(double elapsed_seconds, long nodes) const
   printf("Elapsed Time %e seconds\n", elapsed_seconds);
   printf("FLOP/s %e\n", flops/elapsed_seconds);
   printf("B/s %e\n", bytes/elapsed_seconds);
-  printf("Bandwidth Used:\n");
+  printf("Transfer (estimated):\n");
+  printf("  Local Bytes %lld\n", local_transfer);
+  printf("  Nonlocal Bytes %lld\n", nonlocal_transfer);
   printf("  Local Bandwidth %e B/s\n", local_transfer/elapsed_seconds);
   printf("  Nonlocal Bandwidth %e B/s\n", nonlocal_transfer/elapsed_seconds);
 

--- a/core/core.h
+++ b/core/core.h
@@ -80,7 +80,7 @@ struct App {
   App(int argc, char **argv);
   void check() const;
   void display() const;
-  void report_timing(double elapsed_seconds) const;
+  void report_timing(double elapsed_seconds, long nodes) const;
 };
 
 // Make sure core types are POD

--- a/core/core_c.cc
+++ b/core/core_c.cc
@@ -226,8 +226,8 @@ void app_display(app_t app)
   a->display();
 }
 
-void app_report_timing(app_t app, double elapsed_seconds)
+void app_report_timing(app_t app, double elapsed_seconds, long nodes)
 {
   App *a = unwrap(app);
-  a->report_timing(elapsed_seconds);
+  a->report_timing(elapsed_seconds, nodes);
 }

--- a/core/core_c.h
+++ b/core/core_c.h
@@ -136,7 +136,7 @@ task_graph_list_t app_task_graphs(app_t app);
 bool app_verbose(app_t app);
 void app_check(app_t app);
 void app_display(app_t app);
-void app_report_timing(app_t app, double elapsed_seconds);
+void app_report_timing(app_t app, double elapsed_seconds, long nodes);
 
 #ifdef __cplusplus
 }

--- a/dask/task_bench.py
+++ b/dask/task_bench.py
@@ -67,7 +67,7 @@ def execute_task_bench():
         results.extend(execute_task_graph(task_graph))
     core.join(*results).compute()
     total_time = time.perf_counter() - start_time
-    core.c.app_report_timing(app, total_time)
+    core.c.app_report_timing(app, total_time, 0)
 
 
 if __name__ == "__main__":

--- a/dask/task_bench_direct.py
+++ b/dask/task_bench_direct.py
@@ -93,7 +93,7 @@ def execute_task_bench(client):
     else:
         dask.get(computations, results)
     total_time = time.perf_counter() - start_time
-    core.c.app_report_timing(app, total_time)
+    core.c.app_report_timing(app, total_time, 0)
 
 
 if __name__ == "__main__":

--- a/kernel_bench/main.cc
+++ b/kernel_bench/main.cc
@@ -223,7 +223,7 @@ void KernelBenchApp::execute_main_loop()
   double max_time_end = *std::max_element(time_end,time_end+nb_workers);
   double time_elapsed = max_time_end - min_time_start;
   
-  report_timing(time_elapsed);
+  report_timing(time_elapsed, 0);
   debug_printf(0, "total time (%f, %f) %f ms\n", min_time_start*1e3, max_time_end*1e3, time_elapsed * 1e3);
 }
 

--- a/legion/main.cc
+++ b/legion/main.cc
@@ -624,7 +624,8 @@ void LegionApp::run()
 
   double elapsed = (stop - start) / 1e9;
   if (runtime->get_executing_processor(ctx).address_space() == 0) {
-    report_timing(elapsed);
+    size_t nodes = Realm::Machine::get_machine().get_address_space_count();
+    report_timing(elapsed, nodes);
   }
 }
 

--- a/mpi/bulk_synchronous.cc
+++ b/mpi/bulk_synchronous.cc
@@ -222,8 +222,15 @@ int main(int argc, char *argv[])
     elapsed_time = stop_time - start_time;
   }
 
+  MPI_Info info;
+  MPI_Info_create(&info);
+  MPI_Comm node_comm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &node_comm);
+  int nodes;
+  MPI_Comm_size(MPI_COMM_WORLD, &nodes);
+
   if (rank == 0) {
-    app.report_timing(elapsed_time);
+    app.report_timing(elapsed_time, nodes);
   }
 
   MPI_Finalize();

--- a/mpi/deprecated/alltoall.cc
+++ b/mpi/deprecated/alltoall.cc
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
     double time_elapsed = Timer::time_end();
     if (iter != 0) total_time_elapsed += time_elapsed;
   }
-  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER);
+  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER, 0);
 
   free_output(output_ptrs);
   free_all(graph_send_counts);

--- a/mpi/deprecated/basic.cc
+++ b/mpi/deprecated/basic.cc
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
     /* Average times, but do not include the first run */
     if (iter != 0) total_time_elapsed += time_elapsed;
   }
-  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER);
+  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER, 0);
   free_output(output_ptrs);
   free_data(graph_all_data);
   MPI_Finalize();

--- a/mpi/deprecated/bcast.cc
+++ b/mpi/deprecated/bcast.cc
@@ -356,7 +356,7 @@ int main(int argc, char *argv[])
     double time_elapsed = Timer::time_end();
     if (iter != 0) total_time_elapsed += time_elapsed;
   }
-  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER);
+  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER, 0);
 
   /* Free all memory */
   free_output(output_ptrs);

--- a/mpi/deprecated/buffered_send.cc
+++ b/mpi/deprecated/buffered_send.cc
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
     /* Average times, but do not include the first run */
     if (iter != 0) total_time_elapsed += time_elapsed;
   }
-  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER);
+  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER, 0);
   free_output(output_ptrs);
   free_data(graph_all_data);
   MPI_Finalize();

--- a/mpi/nonblock.cc
+++ b/mpi/nonblock.cc
@@ -220,8 +220,15 @@ int main(int argc, char *argv[])
     elapsed_time = stop_time - start_time;
   }
 
+  MPI_Info info;
+  MPI_Info_create(&info);
+  MPI_Comm node_comm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &node_comm);
+  int nodes;
+  MPI_Comm_size(MPI_COMM_WORLD, &nodes);
+
   if (rank == 0) {
-    app.report_timing(elapsed_time);
+    app.report_timing(elapsed_time, nodes);
   }
 
   MPI_Finalize();

--- a/mpi_openmp/forall.cc
+++ b/mpi_openmp/forall.cc
@@ -228,8 +228,15 @@ int main(int argc, char *argv[])
     elapsed_time = stop_time - start_time;
   }
 
+  MPI_Info info;
+  MPI_Info_create(&info);
+  MPI_Comm node_comm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &node_comm);
+  int nodes;
+  MPI_Comm_size(MPI_COMM_WORLD, &nodes);
+
   if (rank == 0) {
-    app.report_timing(elapsed_time);
+    app.report_timing(elapsed_time, nodes);
   }
 
   MPI_Finalize();

--- a/ompss/main.cc
+++ b/ompss/main.cc
@@ -450,7 +450,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 0);
+  report_timing(elapsed, 1);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/ompss/main.cc
+++ b/ompss/main.cc
@@ -450,7 +450,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed);
+  report_timing(elapsed, 0);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/ompss/main_buffer_core.cc
+++ b/ompss/main_buffer_core.cc
@@ -504,7 +504,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed);
+  report_timing(elapsed, 0);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/ompss/main_buffer_core.cc
+++ b/ompss/main_buffer_core.cc
@@ -504,7 +504,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 0);
+  report_timing(elapsed, 1);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/ompss/main_buffer_core2.cc
+++ b/ompss/main_buffer_core2.cc
@@ -557,7 +557,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT  
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed);
+  report_timing(elapsed, 0);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/ompss/main_buffer_core2.cc
+++ b/ompss/main_buffer_core2.cc
@@ -557,7 +557,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT  
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 0);
+  report_timing(elapsed, 1);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/openmp/main.cc
+++ b/openmp/main.cc
@@ -448,7 +448,7 @@ void OpenMPApp::execute_main_loop()
   }
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed);
+  report_timing(elapsed, 1);
 }
 
 void OpenMPApp::execute_timestep(size_t idx, long t)

--- a/openmp/main_buffer.cc
+++ b/openmp/main_buffer.cc
@@ -440,7 +440,7 @@ void OpenMPApp::execute_main_loop()
   }
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed);
+  report_timing(elapsed, 1);
 }
 
 void OpenMPApp::execute_timestep(size_t idx, long t)

--- a/openmp/main_buffer2.cc
+++ b/openmp/main_buffer2.cc
@@ -480,7 +480,7 @@ void OpenMPApp::execute_main_loop()
   }
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed);
+  report_timing(elapsed, 1);
 }
 
 void OpenMPApp::execute_timestep(size_t idx, long t)

--- a/parsec/main.cc
+++ b/parsec/main.cc
@@ -827,7 +827,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_buffer.cc
+++ b/parsec/main_buffer.cc
@@ -943,7 +943,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_cql.cc
+++ b/parsec/main_cql.cc
@@ -594,7 +594,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_jdf.cc
+++ b/parsec/main_jdf.cc
@@ -301,7 +301,7 @@ void ParsecApp::execute_main_loop()
   double elapsed;
   if (rank == 0) {
     elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d", elapsed, nb_tasks);
   }
 

--- a/parsec/main_multi_taskpool.cc
+++ b/parsec/main_multi_taskpool.cc
@@ -829,7 +829,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_no_insert.cc
+++ b/parsec/main_no_insert.cc
@@ -583,7 +583,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_shard.cc
+++ b/parsec/main_shard.cc
@@ -828,7 +828,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/pygion/main.py
+++ b/pygion/main.py
@@ -474,4 +474,4 @@ def main():
     total_time = (stop_time - start_time)/1e9
 
     if once_only():
-        c.app_report_timing(app, total_time)
+        c.app_report_timing(app, total_time, 0)

--- a/realm/main.cc
+++ b/realm/main.cc
@@ -1122,7 +1122,7 @@ void top_level_task(const void *args, size_t arglen, const void *userdata,
     assert(ok);
   }
 
-  app.report_timing((last_stop - first_start)/1e9);
+  app.report_timing((last_stop - first_start)/1e9, 0);
 }
 
 int main(int argc, char **argv)

--- a/realm_old/main.cc
+++ b/realm_old/main.cc
@@ -1051,7 +1051,7 @@ void top_level_task(const void *args, size_t arglen, const void *userdata,
     assert(ok);
   }
 
-  app.report_timing(last_stop - first_start);
+  app.report_timing(last_stop - first_start, 0);
 }
 
 void *create_byte_array_main(App &config, size_t size_of_byte_array,

--- a/realm_subgraph/main.cc
+++ b/realm_subgraph/main.cc
@@ -1571,7 +1571,7 @@ void top_level_task(const void *args, size_t arglen, const void *userdata,
     assert(ok);
   }
 
-  app.report_timing((last_stop - first_start)/1e9);
+  app.report_timing((last_stop - first_start)/1e9, 0);
 }
 
 int main(int argc, char **argv)

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -510,7 +510,7 @@ local work_task = terralib.memoize(function(n_graphs, n_dsets, max_inputs)
       end)
     end
     actions:insert(rquote
-      core.app_report_timing(app, double(stop_time - start_time)/1e9)
+      core.app_report_timing(app, double(stop_time - start_time)/1e9, 0)
     end)
     return actions
   end

--- a/starpu/main.cc
+++ b/starpu/main.cc
@@ -865,7 +865,7 @@ void StarPUApp::execute_main_loop()
   starpu_mpi_barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
   }
 }
 

--- a/starpu/main_buffer_core.cc
+++ b/starpu/main_buffer_core.cc
@@ -959,7 +959,7 @@ void StarPUApp::execute_main_loop()
   starpu_mpi_barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
   }
 }
 

--- a/starpu/main_expl.cc
+++ b/starpu/main_expl.cc
@@ -963,7 +963,7 @@ void StarPUApp::execute_main_loop()
   starpu_mpi_barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
   }
 }
 

--- a/starpu/main_static.cc
+++ b/starpu/main_static.cc
@@ -1187,7 +1187,7 @@ void StarPUApp::execute_main_loop()
   starpu_mpi_barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed);
+    report_timing(elapsed, 0);
   }
 }
 

--- a/swift/benchmark.swift
+++ b/swift/benchmark.swift
@@ -33,8 +33,8 @@ type pair {
 ];
 
 @dispatch=WORKER
-() reportTiming(string appStr, float elapsedTime) "turbine" "0.0" [
-  "app_report_timing <<appStr>> <<elapsedTime>>"
+() reportTiming(string appStr, float elapsedTime, int nodes) "turbine" "0.0" [
+  "app_report_timing <<appStr>> <<elapsedTime>> <<nodes>>"
 ];
 
 @dispatch=WORKER
@@ -312,7 +312,7 @@ type pair {
         float end = clock() =>
         if (i == 1) {
           location L = locationFromRank(0);
-          @location=L reportTiming(apps[0], end - start);
+          @location=L reportTiming(apps[0], end - start, 0);
         }
         finishedIter[i] = true;
       }

--- a/tensorflow/task_bench.py
+++ b/tensorflow/task_bench.py
@@ -150,7 +150,7 @@ def execute_task_bench():
         start_time = time.perf_counter()
         sess.run(all_output, feed_dict=all_feed)
         total_time = time.perf_counter() - start_time
-    c.app_report_timing(app, total_time, 0)
+    c.app_report_timing(app, total_time, 1)
 
 
 if __name__ == "__main__":

--- a/tensorflow/task_bench.py
+++ b/tensorflow/task_bench.py
@@ -150,7 +150,7 @@ def execute_task_bench():
         start_time = time.perf_counter()
         sess.run(all_output, feed_dict=all_feed)
         total_time = time.perf_counter() - start_time
-    c.app_report_timing(app, total_time)
+    c.app_report_timing(app, total_time, 0)
 
 
 if __name__ == "__main__":

--- a/x10/TaskBench.x10
+++ b/x10/TaskBench.x10
@@ -498,7 +498,7 @@ public class TaskBench {
       }
       delete [] argv;
 
-      app.report_timing(time);
+      app.report_timing(time, 0);
     ") {}
   }
 


### PR DESCRIPTION
This adds support for reporting estimated transfer bytes and bandwidth, which can be used to compute network utilization.

Note that this is an **estimate** because Task Bench cannot know the mapping chosen by the implementation. However, I believe this holds for all current implementations.

The implementation must supply the number of nodes used to execute the job. (The assumption is that dependencies that stay within a node can use a more efficient mechanism, like shared memory, to communicate, and therefore the report splits out the local and nonlocal transfer bytes.) Currently this is only implemented for a subset of systems, #77 tracks the remaining work to be done in finishing off the rest of the implementations.