### PR TITLE
Add -nodes flag to make this configuration uniformly scriptable

### DIFF
--- a/chapel/task_benchmark.chpl
+++ b/chapel/task_benchmark.chpl
@@ -64,7 +64,7 @@ proc main(args: [] string) {
   t.start();
   execute_task_graphs(graphs, task_result, task_ready, task_used);
   t.stop();
-  app_report_timing(app, t.elapsed(), 0);
+  app_report_timing(app, t.elapsed());
 }
 
 proc make_task_result(n_graphs, max_width, max_output_bytes) {

--- a/charm++/main.C
+++ b/charm++/main.C
@@ -77,7 +77,7 @@ void Main::finishedGraph() {
   CkPrintf("Time for last run: %e\n", end - start);
   if (numRunsDone > 1) totalTimeElapsed += (end - start);
   if (numRunsDone == numRuns + 1) {
-    app.report_timing(totalTimeElapsed / numRuns, 0);
+    app.report_timing(totalTimeElapsed / numRuns);
     CkExit();
   } else {
     sectionProxy.reset(new MulticastMsg());

--- a/core/core.h
+++ b/core/core.h
@@ -74,13 +74,14 @@ struct TaskGraph : public task_graph_t {
 
 struct App {
   std::vector<TaskGraph> graphs;
+  long nodes;
   int verbose;
   bool enable_graph_validation;
 
   App(int argc, char **argv);
   void check() const;
   void display() const;
-  void report_timing(double elapsed_seconds, long nodes) const;
+  void report_timing(double elapsed_seconds) const;
 };
 
 // Make sure core types are POD

--- a/core/core_c.cc
+++ b/core/core_c.cc
@@ -226,8 +226,8 @@ void app_display(app_t app)
   a->display();
 }
 
-void app_report_timing(app_t app, double elapsed_seconds, long nodes)
+void app_report_timing(app_t app, double elapsed_seconds)
 {
   App *a = unwrap(app);
-  a->report_timing(elapsed_seconds, nodes);
+  a->report_timing(elapsed_seconds);
 }

--- a/core/core_c.h
+++ b/core/core_c.h
@@ -136,7 +136,7 @@ task_graph_list_t app_task_graphs(app_t app);
 bool app_verbose(app_t app);
 void app_check(app_t app);
 void app_display(app_t app);
-void app_report_timing(app_t app, double elapsed_seconds, long nodes);
+void app_report_timing(app_t app, double elapsed_seconds);
 
 #ifdef __cplusplus
 }

--- a/dask/task_bench.py
+++ b/dask/task_bench.py
@@ -67,7 +67,7 @@ def execute_task_bench():
         results.extend(execute_task_graph(task_graph))
     core.join(*results).compute()
     total_time = time.perf_counter() - start_time
-    core.c.app_report_timing(app, total_time, 0)
+    core.c.app_report_timing(app, total_time)
 
 
 if __name__ == "__main__":

--- a/dask/task_bench_direct.py
+++ b/dask/task_bench_direct.py
@@ -93,7 +93,7 @@ def execute_task_bench(client):
     else:
         dask.get(computations, results)
     total_time = time.perf_counter() - start_time
-    core.c.app_report_timing(app, total_time, 0)
+    core.c.app_report_timing(app, total_time)
 
 
 if __name__ == "__main__":

--- a/kernel_bench/main.cc
+++ b/kernel_bench/main.cc
@@ -223,7 +223,7 @@ void KernelBenchApp::execute_main_loop()
   double max_time_end = *std::max_element(time_end,time_end+nb_workers);
   double time_elapsed = max_time_end - min_time_start;
   
-  report_timing(time_elapsed, 0);
+  report_timing(time_elapsed);
   debug_printf(0, "total time (%f, %f) %f ms\n", min_time_start*1e3, max_time_end*1e3, time_elapsed * 1e3);
 }
 

--- a/legion/main.cc
+++ b/legion/main.cc
@@ -624,8 +624,7 @@ void LegionApp::run()
 
   double elapsed = (stop - start) / 1e9;
   if (runtime->get_executing_processor(ctx).address_space() == 0) {
-    size_t nodes = Realm::Machine::get_machine().get_address_space_count();
-    report_timing(elapsed, nodes);
+    report_timing(elapsed);
   }
 }
 

--- a/mpi/bulk_synchronous.cc
+++ b/mpi/bulk_synchronous.cc
@@ -222,15 +222,8 @@ int main(int argc, char *argv[])
     elapsed_time = stop_time - start_time;
   }
 
-  MPI_Info info;
-  MPI_Info_create(&info);
-  MPI_Comm node_comm;
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &node_comm);
-  int nodes;
-  MPI_Comm_size(MPI_COMM_WORLD, &nodes);
-
   if (rank == 0) {
-    app.report_timing(elapsed_time, nodes);
+    app.report_timing(elapsed_time);
   }
 
   MPI_Finalize();

--- a/mpi/deprecated/alltoall.cc
+++ b/mpi/deprecated/alltoall.cc
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
     double time_elapsed = Timer::time_end();
     if (iter != 0) total_time_elapsed += time_elapsed;
   }
-  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER, 0);
+  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER);
 
   free_output(output_ptrs);
   free_all(graph_send_counts);

--- a/mpi/deprecated/basic.cc
+++ b/mpi/deprecated/basic.cc
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
     /* Average times, but do not include the first run */
     if (iter != 0) total_time_elapsed += time_elapsed;
   }
-  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER, 0);
+  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER);
   free_output(output_ptrs);
   free_data(graph_all_data);
   MPI_Finalize();

--- a/mpi/deprecated/bcast.cc
+++ b/mpi/deprecated/bcast.cc
@@ -356,7 +356,7 @@ int main(int argc, char *argv[])
     double time_elapsed = Timer::time_end();
     if (iter != 0) total_time_elapsed += time_elapsed;
   }
-  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER, 0);
+  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER);
 
   /* Free all memory */
   free_output(output_ptrs);

--- a/mpi/deprecated/buffered_send.cc
+++ b/mpi/deprecated/buffered_send.cc
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
     /* Average times, but do not include the first run */
     if (iter != 0) total_time_elapsed += time_elapsed;
   }
-  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER, 0);
+  if (taskid == MASTER) new_app.report_timing(total_time_elapsed / NUM_ITER);
   free_output(output_ptrs);
   free_data(graph_all_data);
   MPI_Finalize();

--- a/mpi/nonblock.cc
+++ b/mpi/nonblock.cc
@@ -220,15 +220,8 @@ int main(int argc, char *argv[])
     elapsed_time = stop_time - start_time;
   }
 
-  MPI_Info info;
-  MPI_Info_create(&info);
-  MPI_Comm node_comm;
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &node_comm);
-  int nodes;
-  MPI_Comm_size(MPI_COMM_WORLD, &nodes);
-
   if (rank == 0) {
-    app.report_timing(elapsed_time, nodes);
+    app.report_timing(elapsed_time);
   }
 
   MPI_Finalize();

--- a/mpi_openmp/forall.cc
+++ b/mpi_openmp/forall.cc
@@ -228,15 +228,8 @@ int main(int argc, char *argv[])
     elapsed_time = stop_time - start_time;
   }
 
-  MPI_Info info;
-  MPI_Info_create(&info);
-  MPI_Comm node_comm;
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &node_comm);
-  int nodes;
-  MPI_Comm_size(MPI_COMM_WORLD, &nodes);
-
   if (rank == 0) {
-    app.report_timing(elapsed_time, nodes);
+    app.report_timing(elapsed_time);
   }
 
   MPI_Finalize();

--- a/ompss/main.cc
+++ b/ompss/main.cc
@@ -450,7 +450,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 1);
+  report_timing(elapsed);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/ompss/main_buffer_core.cc
+++ b/ompss/main_buffer_core.cc
@@ -504,7 +504,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 1);
+  report_timing(elapsed);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/ompss/main_buffer_core2.cc
+++ b/ompss/main_buffer_core2.cc
@@ -557,7 +557,7 @@ void OmpSsApp::execute_main_loop()
 OMPSS_TASKWAIT  
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 1);
+  report_timing(elapsed);
 }
 
 void OmpSsApp::execute_timestep(size_t idx, long t)

--- a/openmp/main.cc
+++ b/openmp/main.cc
@@ -448,7 +448,7 @@ void OpenMPApp::execute_main_loop()
   }
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 1);
+  report_timing(elapsed);
 }
 
 void OpenMPApp::execute_timestep(size_t idx, long t)

--- a/openmp/main_buffer.cc
+++ b/openmp/main_buffer.cc
@@ -440,7 +440,7 @@ void OpenMPApp::execute_main_loop()
   }
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 1);
+  report_timing(elapsed);
 }
 
 void OpenMPApp::execute_timestep(size_t idx, long t)

--- a/openmp/main_buffer2.cc
+++ b/openmp/main_buffer2.cc
@@ -480,7 +480,7 @@ void OpenMPApp::execute_main_loop()
   }
   
   double elapsed = Timer::time_end();
-  report_timing(elapsed, 1);
+  report_timing(elapsed);
 }
 
 void OpenMPApp::execute_timestep(size_t idx, long t)

--- a/parsec/main.cc
+++ b/parsec/main.cc
@@ -827,7 +827,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_buffer.cc
+++ b/parsec/main_buffer.cc
@@ -943,7 +943,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_cql.cc
+++ b/parsec/main_cql.cc
@@ -594,7 +594,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_jdf.cc
+++ b/parsec/main_jdf.cc
@@ -301,7 +301,7 @@ void ParsecApp::execute_main_loop()
   double elapsed;
   if (rank == 0) {
     elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d", elapsed, nb_tasks);
   }
 

--- a/parsec/main_multi_taskpool.cc
+++ b/parsec/main_multi_taskpool.cc
@@ -829,7 +829,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_no_insert.cc
+++ b/parsec/main_no_insert.cc
@@ -583,7 +583,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/parsec/main_shard.cc
+++ b/parsec/main_shard.cc
@@ -828,7 +828,7 @@ void ParsecApp::execute_main_loop()
   MPI_Barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
     debug_printf(0, "[****] TIME(s) %12.5f : \tnb_tasks %d\n", elapsed, nb_tasks);
   }
 

--- a/pygion/main.py
+++ b/pygion/main.py
@@ -474,4 +474,4 @@ def main():
     total_time = (stop_time - start_time)/1e9
 
     if once_only():
-        c.app_report_timing(app, total_time, 0)
+        c.app_report_timing(app, total_time)

--- a/realm/main.cc
+++ b/realm/main.cc
@@ -1122,7 +1122,7 @@ void top_level_task(const void *args, size_t arglen, const void *userdata,
     assert(ok);
   }
 
-  app.report_timing((last_stop - first_start)/1e9, 0);
+  app.report_timing((last_stop - first_start)/1e9);
 }
 
 int main(int argc, char **argv)

--- a/realm_old/main.cc
+++ b/realm_old/main.cc
@@ -1051,7 +1051,7 @@ void top_level_task(const void *args, size_t arglen, const void *userdata,
     assert(ok);
   }
 
-  app.report_timing(last_stop - first_start, 0);
+  app.report_timing(last_stop - first_start);
 }
 
 void *create_byte_array_main(App &config, size_t size_of_byte_array,

--- a/realm_subgraph/main.cc
+++ b/realm_subgraph/main.cc
@@ -1571,7 +1571,7 @@ void top_level_task(const void *args, size_t arglen, const void *userdata,
     assert(ok);
   }
 
-  app.report_timing((last_stop - first_start)/1e9, 0);
+  app.report_timing((last_stop - first_start)/1e9);
 }
 
 int main(int argc, char **argv)

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -510,7 +510,7 @@ local work_task = terralib.memoize(function(n_graphs, n_dsets, max_inputs)
       end)
     end
     actions:insert(rquote
-      core.app_report_timing(app, double(stop_time - start_time)/1e9, 0)
+      core.app_report_timing(app, double(stop_time - start_time)/1e9)
     end)
     return actions
   end

--- a/starpu/main.cc
+++ b/starpu/main.cc
@@ -865,7 +865,7 @@ void StarPUApp::execute_main_loop()
   starpu_mpi_barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
   }
 }
 

--- a/starpu/main_buffer_core.cc
+++ b/starpu/main_buffer_core.cc
@@ -959,7 +959,7 @@ void StarPUApp::execute_main_loop()
   starpu_mpi_barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
   }
 }
 

--- a/starpu/main_expl.cc
+++ b/starpu/main_expl.cc
@@ -963,7 +963,7 @@ void StarPUApp::execute_main_loop()
   starpu_mpi_barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
   }
 }
 

--- a/starpu/main_static.cc
+++ b/starpu/main_static.cc
@@ -1187,7 +1187,7 @@ void StarPUApp::execute_main_loop()
   starpu_mpi_barrier(MPI_COMM_WORLD);
   if (rank == 0) {
     double elapsed = Timer::time_end();
-    report_timing(elapsed, 0);
+    report_timing(elapsed);
   }
 }
 

--- a/swift/benchmark.swift
+++ b/swift/benchmark.swift
@@ -33,8 +33,8 @@ type pair {
 ];
 
 @dispatch=WORKER
-() reportTiming(string appStr, float elapsedTime, int nodes) "turbine" "0.0" [
-  "app_report_timing <<appStr>> <<elapsedTime>> <<nodes>>"
+() reportTiming(string appStr, float elapsedTime) "turbine" "0.0" [
+  "app_report_timing <<appStr>> <<elapsedTime>>"
 ];
 
 @dispatch=WORKER
@@ -312,7 +312,7 @@ type pair {
         float end = clock() =>
         if (i == 1) {
           location L = locationFromRank(0);
-          @location=L reportTiming(apps[0], end - start, 0);
+          @location=L reportTiming(apps[0], end - start);
         }
         finishedIter[i] = true;
       }

--- a/tensorflow/task_bench.py
+++ b/tensorflow/task_bench.py
@@ -150,7 +150,7 @@ def execute_task_bench():
         start_time = time.perf_counter()
         sess.run(all_output, feed_dict=all_feed)
         total_time = time.perf_counter() - start_time
-    c.app_report_timing(app, total_time, 1)
+    c.app_report_timing(app, total_time)
 
 
 if __name__ == "__main__":

--- a/test_all.sh
+++ b/test_all.sh
@@ -43,18 +43,18 @@ if [[ $TASKBENCH_USE_MPI -eq 1 ]]; then
     for t in "${extended_types[@]}"; do
         for k in "${kernels[@]}"; do
             for binary in nonblock bulk_synchronous; do
-                mpirun -np 1 ./mpi/$binary -steps $steps -type $t $k
-                mpirun -np 2 ./mpi/$binary -steps $steps -type $t $k
-                mpirun -np 4 ./mpi/$binary -steps $steps -type $t $k
-                mpirun -np 4 ./mpi/$binary -steps $steps -type $t $k -and -steps $steps -type $t $k
+                mpirun -np 1 ./mpi/$binary -steps $steps -type $t $k -nodes 1
+                mpirun -np 2 ./mpi/$binary -steps $steps -type $t $k -nodes 2
+                mpirun -np 4 ./mpi/$binary -steps $steps -type $t $k -nodes 4
+                mpirun -np 4 ./mpi/$binary -steps $steps -type $t $k -and -steps $steps -type $t $k -nodes 4
             done
         done
     done
     for t in no_comm stencil_1d stencil_1d_periodic all_to_all; do # FIXME: trivial dom tree fft nearest spread random_nearest are broken
         for k in "${kernels[@]}"; do
             for binary in deprecated/bcast deprecated/alltoall deprecated/buffered_send; do
-                mpirun -np 4 ./mpi/$binary -steps $steps -type $t $k
-                mpirun -np 4 ./mpi/$binary -steps $steps -type $t $k -and -steps $steps -type $t $k
+                mpirun -np 4 ./mpi/$binary -steps $steps -type $t $k -nodes 4
+                mpirun -np 4 ./mpi/$binary -steps $steps -type $t $k -and -steps $steps -type $t $k -nodes 4
             done
         done
     done
@@ -63,10 +63,10 @@ fi
 if [[ $USE_MPI_OPENMP -eq 1 ]]; then
     for t in "${extended_types[@]}"; do
         for k in "${kernels[@]}"; do
-            mpirun -np 1 ./mpi_openmp/forall -steps $steps -type $t $k
-            mpirun -np 2 ./mpi_openmp/forall -steps $steps -type $t $k
-            mpirun -np 4 ./mpi_openmp/forall -steps $steps -type $t $k
-            mpirun -np 4 ./mpi_openmp/forall -steps $steps -type $t $k -and -steps $steps -type $t $k
+            mpirun -np 1 ./mpi_openmp/forall -steps $steps -type $t $k -nodes 1
+            mpirun -np 2 ./mpi_openmp/forall -steps $steps -type $t $k -nodes 2
+            mpirun -np 4 ./mpi_openmp/forall -steps $steps -type $t $k -nodes 4
+            mpirun -np 4 ./mpi_openmp/forall -steps $steps -type $t $k -and -steps $steps -type $t $k -nodes 4
         done
     done
 fi
@@ -76,10 +76,10 @@ if [[ $USE_LEGION -eq 1 ]]; then
         for k in "${kernels[@]}"; do
             ./legion/task_bench -steps $steps -type $t $k -ll:cpu 2
             if [[ $USE_GASNET -eq 1 ]]; then
-                mpirun -np 2 ./legion/task_bench -steps $steps -type $t $k -ll:cpu 1
-                mpirun -np 4 ./legion/task_bench -steps $steps -type $t $k -ll:cpu 1
+                mpirun -np 2 ./legion/task_bench -steps $steps -type $t $k -ll:cpu 1 -nodes 2
+                mpirun -np 4 ./legion/task_bench -steps $steps -type $t $k -ll:cpu 1 -nodes 4
             fi
-            ./legion/task_bench -steps $steps -type $t $k -and -steps $steps -type $t $k -ll:cpu 2
+            ./legion/task_bench -steps $steps -type $t $k -and -steps $steps -type $t $k -ll:cpu 2 -nodes 1
         done
     done
 fi
@@ -106,9 +106,9 @@ if [[ $USE_REALM -eq 1 ]]; then
                     ./$variant/task_bench -steps $steps -type $t $k -ll:cpu 2 $option
                     ./$variant/task_bench -steps $steps -type $t $k -ll:cpu 4 $option
                     if [[ $USE_GASNET -eq 1 ]]; then
-                        mpirun -np 2 ./$variant/task_bench -steps $steps -type $t $k -ll:cpu 1 $option
-                        mpirun -np 2 ./$variant/task_bench -steps $steps -type $t $k -ll:cpu 2 $option
-                        mpirun -np 4 ./$variant/task_bench -steps $steps -type $t $k -ll:cpu 1 $option
+                        mpirun -np 2 ./$variant/task_bench -steps $steps -type $t $k -ll:cpu 1 $option -nodes 2
+                        mpirun -np 2 ./$variant/task_bench -steps $steps -type $t $k -ll:cpu 2 $option -nodes 2
+                        mpirun -np 4 ./$variant/task_bench -steps $steps -type $t $k -ll:cpu 1 $option -nodes 4
                     fi
                     ./$variant/task_bench -steps $steps -type $t $k -and -steps $steps -type $t $k -ll:cpu 2 $option
                 done
@@ -119,9 +119,9 @@ if [[ $USE_REALM -eq 1 ]]; then
             ./realm_old/task_bench -steps 9 -type $t $k -ll:cpu 2
             ./realm_old/task_bench -steps 9 -type $t $k -ll:cpu 4
             if [[ $USE_GASNET -eq 1 ]]; then
-                mpirun -np 2 ./realm_old/task_bench -steps 9 -type $t $k -ll:cpu 1
-                mpirun -np 2 ./realm_old/task_bench -steps 9 -type $t $k -ll:cpu 2
-                mpirun -np 4 ./realm_old/task_bench -steps 9 -type $t $k -ll:cpu 1
+                mpirun -np 2 ./realm_old/task_bench -steps 9 -type $t $k -ll:cpu 1 -nodes 2
+                mpirun -np 2 ./realm_old/task_bench -steps 9 -type $t $k -ll:cpu 2 -nodes 2
+                mpirun -np 4 ./realm_old/task_bench -steps 9 -type $t $k -ll:cpu 1 -nodes 4
             fi
             ./realm_old/task_bench -steps 9 -type $t $k -and -steps 9 -type $t $k -ll:cpu 2
         done
@@ -142,66 +142,43 @@ if [[ $USE_STARPU -eq 1 ]]; then
     export STARPU_RESERVE_NCPU=1
     for t in "${basic_types[@]}"; do
         for k in "${kernels[@]}"; do
-            mpirun -np 1 ./starpu/main -steps $steps -type $t $k -core 2
-            mpirun -np 4 ./starpu/main -steps $steps -type $t $k -p 1 -core 2
-            mpirun -np 4 ./starpu/main -steps $steps -type $t $k -p 2 -core 2
-            mpirun -np 4 ./starpu/main -field 4 -steps $steps -type $t $k -p 2 -core 2
-            mpirun -np 4 ./starpu/main -steps $steps -type $t $k -p 4 -core 2
-            mpirun -np 1 ./starpu/main -steps $steps -type $t $k -and -steps $steps -type $t $k -core 2
-            mpirun -np 4 ./starpu/main -steps 16 -width 8 -type $t $k -p 1 -core 2 -S
-            mpirun -np 4 ./starpu/main -steps 16 -width 8 -type $t $k -and -steps 16 -width 8 -type $t $k -core 2 -p 1 -S
+            for binary in main main_expl; do
+                mpirun -np 1 ./starpu/$binary -steps $steps -type $t $k -core 2 -nodes 1
+                mpirun -np 4 ./starpu/$binary -steps $steps -type $t $k -p 1 -core 2 -nodes 4
+                mpirun -np 4 ./starpu/$binary -steps $steps -type $t $k -p 2 -core 2 -nodes 4
+                mpirun -np 4 ./starpu/$binary -field 4 -steps $steps -type $t $k -p 2 -core 2 -nodes 4
+                mpirun -np 4 ./starpu/$binary -steps $steps -type $t $k -p 4 -core 2 -nodes 4
+                mpirun -np 1 ./starpu/$binary -steps $steps -type $t $k -and -steps $steps -type $t $k -core 2 -nodes 1
+                mpirun -np 4 ./starpu/$binary -steps 16 -width 8 -type $t $k -p 1 -core 2 -S -nodes 4
+                mpirun -np 4 ./starpu/$binary -steps 16 -width 8 -type $t $k -and -steps 16 -width 8 -type $t $k -core 2 -p 1 -S -nodes 4
+            done
         done
     done
-
-    for t in "${basic_types[@]}"; do
-        for k in "${kernels[@]}"; do
-            mpirun -np 1 ./starpu/main_expl -steps $steps -type $t $k -core 2
-            mpirun -np 4 ./starpu/main_expl -steps $steps -type $t $k -p 1 -core 2
-            mpirun -np 4 ./starpu/main_expl -steps $steps -type $t $k -p 2 -core 2
-            mpirun -np 4 ./starpu/main_expl -field 4 -steps $steps -type $t $k -p 2 -core 2
-            mpirun -np 4 ./starpu/main_expl -steps $steps -type $t $k -p 4 -core 2
-            mpirun -np 1 ./starpu/main_expl -steps $steps -type $t $k -and -steps $steps -type $t $k -core 2
-            mpirun -np 4 ./starpu/main_expl -steps 16 -width 8 -type $t $k -p 1 -core 2 -S
-            mpirun -np 4 ./starpu/main_expl -steps 16 -width 8 -type $t $k -and -steps 16 -width 8 -type $t $k -core 2 -p 1 -S
-        done
-    done
-
-#    for t in "${basic_types[@]}"; do
-#        for k in "${kernels[@]}"; do
-#            mpirun -np 1 ./starpu/main_static -steps $steps -type $t $k -core 2
-#            mpirun -np 4 ./starpu/main_static -steps $steps -type $t $k -p 1 -core 2
-#            mpirun -np 4 ./starpu/main_static -steps $steps -type $t $k -p 2 -core 2
-#            mpirun -np 4 ./starpu/main_static -steps $steps -type $t $k -p 4 -core 2
-#            mpirun -np 1 ./starpu/main_static -steps $steps -type $t $k -and -steps $steps -type $t $k -core 2
-#            mpirun -np 4 ./starpu/main_static -steps 16 -width 8 -type $t $k -p 1 -core 2 -S
-#            mpirun -np 4 ./starpu/main_static -steps 16 -width 8 -type $t $k -and -steps 16 -width 8 -type $t $k -core 2 -p 1 -S
-#        done
-#    done
 fi
 
 if [[ $USE_PARSEC -eq 1 ]]; then
     for t in "${basic_types[@]}"; do
         for k in "${kernels[@]}"; do
-            mpirun -np 1 ./parsec/main_shard -steps $steps -type $t $k -c 2 -p 1
-            mpirun -np 4 ./parsec/main_shard -width 16 -steps $steps -type $t $k -p 1 -c 2 -S 4
-            mpirun -np 1 ./parsec/main_shard -steps $steps -type $t $k -and -steps $steps -type $t $k -c 2 -p 1
-            mpirun -np 1 ./parsec/main_buffer -steps $steps -type $t $k -c 2
-            mpirun -np 4 ./parsec/main_buffer -steps $steps -type $t $k -p 1 -c 2
-            mpirun -np 4 ./parsec/main_buffer -steps $steps -type $t $k -p 2 -c 2
-            mpirun -np 4 ./parsec/main_buffer -steps $steps -type $t $k -p 4 -c 2
-            mpirun -np 1 ./parsec/main_buffer -steps $steps -type $t $k -and -steps $steps -type $t $k -c 2
-            mpirun -np 1 ./parsec/main_dtd -steps $steps -type $t $k -c 2
-            mpirun -np 4 ./parsec/main_dtd -steps $steps -type $t $k -p 1 -c 2
-            mpirun -np 4 ./parsec/main_dtd -steps $steps -type $t $k -p 2 -c 2
-            mpirun -np 4 ./parsec/main_dtd -steps $steps -type $t $k -p 4 -c 2
-            mpirun -np 1 ./parsec/main_dtd -steps $steps -type $t $k -and -steps $steps -type $t $k -c 2
+            mpirun -np 1 ./parsec/main_shard -steps $steps -type $t $k -c 2 -p 1 -nodes 1
+            mpirun -np 4 ./parsec/main_shard -width 16 -steps $steps -type $t $k -p 1 -c 2 -S 4 -nodes 4
+            mpirun -np 1 ./parsec/main_shard -steps $steps -type $t $k -and -steps $steps -type $t $k -c 2 -p 1 -nodes 1
+            mpirun -np 1 ./parsec/main_buffer -steps $steps -type $t $k -c 2 -nodes 1
+            mpirun -np 4 ./parsec/main_buffer -steps $steps -type $t $k -p 1 -c 2 -nodes 4
+            mpirun -np 4 ./parsec/main_buffer -steps $steps -type $t $k -p 2 -c 2 -nodes 4
+            mpirun -np 4 ./parsec/main_buffer -steps $steps -type $t $k -p 4 -c 2 -nodes 4
+            mpirun -np 1 ./parsec/main_buffer -steps $steps -type $t $k -and -steps $steps -type $t $k -c 2 -nodes 1
+            mpirun -np 1 ./parsec/main_dtd -steps $steps -type $t $k -c 2 -nodes 1
+            mpirun -np 4 ./parsec/main_dtd -steps $steps -type $t $k -p 1 -c 2 -nodes 4
+            mpirun -np 4 ./parsec/main_dtd -steps $steps -type $t $k -p 2 -c 2 -nodes 4
+            mpirun -np 4 ./parsec/main_dtd -steps $steps -type $t $k -p 4 -c 2 -nodes 4
+            mpirun -np 1 ./parsec/main_dtd -steps $steps -type $t $k -and -steps $steps -type $t $k -c 2 -nodes 1
         done
     done
     for k in "${kernels[@]}"; do
-        mpirun -np 2 ./parsec/main_ptg -p 1 -S 4 -c 2 -steps $steps -type stencil_1d $k -width 8 -field 2
-        mpirun -np 2 ./parsec/main_ptg -p 1 -S 4 -c 2 -steps $steps -type stencil_1d $k -width 8 -and -steps $steps -type stencil_1d $k -width 8
-        mpirun -np 2 ./parsec/main_ptg -p 1 -S 4 -c 2 -steps $steps -type nearest -radix 5 $k -width 8 -field 2
-        mpirun -np 2 ./parsec/main_ptg -p 1 -S 4 -c 2 -steps $steps -type nearest -radix 5 $k -width 8 -and -steps $steps -type nearest -radix 5 $k -width 8
+        mpirun -np 2 ./parsec/main_ptg -p 1 -S 4 -c 2 -steps $steps -type stencil_1d $k -width 8 -field 2 -nodes 2
+        mpirun -np 2 ./parsec/main_ptg -p 1 -S 4 -c 2 -steps $steps -type stencil_1d $k -width 8 -and -steps $steps -type stencil_1d $k -width 8 -nodes 2
+        mpirun -np 2 ./parsec/main_ptg -p 1 -S 4 -c 2 -steps $steps -type nearest -radix 5 $k -width 8 -field 2 -nodes 2
+        mpirun -np 2 ./parsec/main_ptg -p 1 -S 4 -c 2 -steps $steps -type nearest -radix 5 $k -width 8 -and -steps $steps -type nearest -radix 5 $k -width 8 -nodes 2
     done
 fi
 
@@ -229,10 +206,10 @@ fi
 
     for t in "${extended_types[@]}"; do
         for k in "${kernels[@]}"; do
-            mpirun -np 1 ./x10/main -steps $steps -type $t $k
-            mpirun -np 2 ./x10/main -steps $steps -type $t $k
-            mpirun -np 4 ./x10/main -steps $steps -type $t $k
-            mpirun -np 4 ./x10/main -steps $steps -type $t $k -and -steps $steps -type $t $k
+            mpirun -np 1 ./x10/main -steps $steps -type $t $k -nodes 1
+            mpirun -np 2 ./x10/main -steps $steps -type $t $k -nodes 2
+            mpirun -np 4 ./x10/main -steps $steps -type $t $k -nodes 4
+            mpirun -np 4 ./x10/main -steps $steps -type $t $k -and -steps $steps -type $t $k -nodes 4
         done
     done
 fi)

--- a/x10/TaskBench.x10
+++ b/x10/TaskBench.x10
@@ -498,7 +498,7 @@ public class TaskBench {
       }
       delete [] argv;
 
-      app.report_timing(time, 0);
+      app.report_timing(time);
     ") {}
   }
 


### PR DESCRIPTION
Fixes #77 by adding a uniformly scriptable interface so that we don't need to infer the number of nodes separately on each system.

The intended use for this flag is that it would be fed with the number of nodes provided by the job scheduler, e.g.:

```
srun ./task_bench -nodes $SLURM_JOB_NUM_NODES
```

In this way it doesn't matter what the implementation's notion of a "node" is and whether such a concept even exists.