### PR TITLE
Run CI on Ubuntu 20.04 and upgrade many dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           # - system: OMPSS
           # - system: OMPSS2
           #   hwloc: 1
-          - system: SWIFT
+          # - system: SWIFT
           - system: TENSORFLOW
           - system: DASK
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
           - system: SWIFT
           - system: TENSORFLOW
           - system: DASK
+      fail-fast: false
     steps:
       - uses: actions/checkout@v1
       - run: ./ci.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build (${{matrix.system}})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,9 @@ jobs:
           - system: X10
           - system: OPENMP
           # - system: SPARK
-          - system: OMPSS
-          - system: OMPSS2
-            hwloc: 1
+          # - system: OMPSS
+          # - system: OMPSS2
+          #   hwloc: 1
           - system: SWIFT
           - system: TENSORFLOW
           - system: DASK

--- a/build_all.sh
+++ b/build_all.sh
@@ -201,6 +201,7 @@ fi)
     popd
 
     ls -lR "$CHPL_HOME/bin" # FIXME: Elliott: debug
+    env | grep CHPL
 
     make -C chapel clean
     make -C chapel

--- a/build_all.sh
+++ b/build_all.sh
@@ -441,7 +441,7 @@ EOF
         export CRAY_ARGS="--with-launcher=/usr/bin/srun"
     fi
 
-    ./dev/build/build-all.sh
+    ./dev/build/build-swift-t.sh
     find "$SWIFT_PREFIX"/stc -type f -exec sed -i 's@#!/bin/zsh@'"#!$SWIFT_PREFIX"'/bin/zsh@g' {} +
     find "$SWIFT_PREFIX"/turbine -type f -exec sed -i 's@#!/bin/zsh@'"#!$SWIFT_PREFIX"'/bin/zsh@g' {} +
     popd

--- a/build_all.sh
+++ b/build_all.sh
@@ -105,10 +105,10 @@ if [[ $USE_REGENT -eq 1 ]]; then
             export CXX=c++
         fi
         unset LG_RT_DIR
-        if [[ -z $TRAVIS ]]; then
-            ./scripts/setup_env.py --terra-url https://github.com/StanfordLegion/terra.git --terra-branch luajit2.1 --llvm-version=38 --terra-cmake -j$THREADS
+        if [[ -z $GITHUB_ACTIONS ]]; then
+            ./scripts/setup_env.py -j$THREADS
         else
-            ./install.py --terra-url https://github.com/StanfordLegion/terra.git --terra-branch luajit2.1 --rdir=auto
+            ./install.py --rdir=auto
         fi
     )
     popd

--- a/build_all.sh
+++ b/build_all.sh
@@ -410,7 +410,7 @@ EOF
         export PATH="$PWD"/cc-wrapper:"$PATH"
     fi
 
-    pushd swift-t-1.4.3
+    pushd swift-t-1.5.0
     if [[ ! -f ./dev/build/swift-t-settings.sh ]]; then
         ./dev/build/init-settings.sh
         sed -i 's@SWIFT_T_PREFIX=/tmp/swift-t-install@SWIFT_T_PREFIX='"$SWIFT_PREFIX"'@g' ./dev/build/swift-t-settings.sh

--- a/build_all.sh
+++ b/build_all.sh
@@ -410,7 +410,7 @@ EOF
         export PATH="$PWD"/cc-wrapper:"$PATH"
     fi
 
-    pushd swift-t-1.5.0
+    pushd swift-t-1.4.3
     if [[ ! -f ./dev/build/swift-t-settings.sh ]]; then
         ./dev/build/init-settings.sh
         sed -i 's@SWIFT_T_PREFIX=/tmp/swift-t-install@SWIFT_T_PREFIX='"$SWIFT_PREFIX"'@g' ./dev/build/swift-t-settings.sh

--- a/build_all.sh
+++ b/build_all.sh
@@ -195,11 +195,12 @@ fi)
         module load craype-hugepages16M
     fi
 
-    ls -lR "$CHPL_HOME/bin" # FIXME: Elliott: debug
     export PATH="$CHPL_HOME/bin/$CHPL_HOST_PLATFORM:$PATH"
     pushd "$CHPL_HOME"
     make -j$THREADS
     popd
+
+    ls -lR "$CHPL_HOME/bin" # FIXME: Elliott: debug
 
     make -C chapel clean
     make -C chapel

--- a/build_all.sh
+++ b/build_all.sh
@@ -410,7 +410,7 @@ EOF
         export PATH="$PWD"/cc-wrapper:"$PATH"
     fi
 
-    pushd swift-t-1.4
+    pushd swift-t-1.5.0
     if [[ ! -f ./dev/build/swift-t-settings.sh ]]; then
         ./dev/build/init-settings.sh
         sed -i 's@SWIFT_T_PREFIX=/tmp/swift-t-install@SWIFT_T_PREFIX='"$SWIFT_PREFIX"'@g' ./dev/build/swift-t-settings.sh

--- a/build_all.sh
+++ b/build_all.sh
@@ -195,13 +195,10 @@ fi)
         module load craype-hugepages16M
     fi
 
-    export PATH="$CHPL_HOME/bin/$CHPL_HOST_PLATFORM:$PATH"
+    export PATH="$CHPL_HOME/bin/$CHPL_HOST_PLATFORM-$CHPL_HOST_ARCH:$PATH"
     pushd "$CHPL_HOME"
     make -j$THREADS
     popd
-
-    ls -lR "$CHPL_HOME/bin" # FIXME: Elliott: debug
-    env | grep CHPL
 
     make -C chapel clean
     make -C chapel

--- a/build_all.sh
+++ b/build_all.sh
@@ -195,6 +195,7 @@ fi)
         module load craype-hugepages16M
     fi
 
+    ls -lR "$CHPL_HOME/bin" # FIXME: Elliott: debug
     export PATH="$CHPL_HOME/bin/$CHPL_HOST_PLATFORM:$PATH"
     pushd "$CHPL_HOME"
     make -j$THREADS

--- a/ci.sh
+++ b/ci.sh
@@ -13,7 +13,7 @@ if [[ "$(uname)" = "Linux" ]]; then
   sudo apt-get update -qq
   sudo apt-get install -qq mpich libmpich-dev libpcre3-dev binutils-dev
   if [[ $USE_CHAPEL -eq 1 || $USE_REGENT -eq 1 ]]; then
-    sudo apt-get install -qq clang-6.0 libclang-6.0-dev llvm-6.0-dev libedit-dev
+    sudo apt-get install -qq clang-12 libclang-12-dev llvm-12-dev libedit-dev
   fi
   if [[ $USE_OMPSS2 -eq 1 ]]; then
     sudo apt-get install -qq libnuma-dev gperf libboost1.71-dev

--- a/ci.sh
+++ b/ci.sh
@@ -13,7 +13,7 @@ if [[ "$(uname)" = "Linux" ]]; then
   sudo apt-get update -qq
   sudo apt-get install -qq mpich libmpich-dev libpcre3-dev binutils-dev
   if [[ $USE_CHAPEL -eq 1 || $USE_REGENT -eq 1 ]]; then
-    sudo apt-get install -qq clang-12 libclang-12-dev llvm-12-dev libedit-dev
+    sudo apt-get install -qq clang-12 libclang-12-dev llvm-12-dev libedit-dev libncurses5-dev zlib1g-dev
   fi
   if [[ $USE_OMPSS2 -eq 1 ]]; then
     sudo apt-get install -qq libnuma-dev gperf libboost1.71-dev

--- a/ci.sh
+++ b/ci.sh
@@ -13,7 +13,8 @@ if [[ "$(uname)" = "Linux" ]]; then
   sudo apt-get update -qq
   sudo apt-get install -qq mpich libmpich-dev libpcre3-dev binutils-dev
   if [[ $USE_CHAPEL -eq 1 || $USE_REGENT -eq 1 ]]; then
-    sudo apt-get install -qq clang-12 libclang-12-dev llvm-12-dev libedit-dev libncurses5-dev zlib1g-dev
+    sudo apt-get install -qq clang-12 libclang-12-dev libclang-cpp12-dev llvm-12-dev libedit-dev libncurses5-dev zlib1g-dev
+    export CMAKE_PREFIX_PATH=/usr/lib/llvm-12:/usr/share/llvm-12
   fi
   if [[ $USE_OMPSS2 -eq 1 ]]; then
     sudo apt-get install -qq libnuma-dev gperf libboost1.71-dev

--- a/ci.sh
+++ b/ci.sh
@@ -16,7 +16,7 @@ if [[ "$(uname)" = "Linux" ]]; then
     sudo apt-get install -qq clang-6.0 libclang-6.0-dev llvm-6.0-dev libedit-dev
   fi
   if [[ $USE_OMPSS2 -eq 1 ]]; then
-    sudo apt-get install -qq libnuma-dev gperf libboost1.65-dev
+    sudo apt-get install -qq libnuma-dev gperf libboost1.71-dev
   fi
   if [[ $USE_PARSEC -eq 1 ]]; then
     sudo snap install cmake --classic

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -296,16 +296,16 @@ if [[ $USE_OMPSS -eq 1 ]]; then
     export OMPSS_DL_DIR="$TASKBENCH_DEPS_DIR"/ompss
     cat >>deps/env.sh <<EOF
 export OMPSS_DL_DIR="\$TASKBENCH_DEPS_DIR"/ompss
-export NANOS_SRC_DIR="\$OMPSS_DL_DIR"/nanox-0.14.1
-export NANOS_PREFIX="\$OMPSS_DL_DIR"/nanox-0.14.1/install
-export MERCURIUM_SRC_DIR="\$OMPSS_DL_DIR"/mcxx-2.1.0
-export MERCURIUM_PREFIX="\$OMPSS_DL_DIR"/mcxx-2.1.0/install
+export NANOS_SRC_DIR="\$OMPSS_DL_DIR"/nanox-0.15
+export NANOS_PREFIX="\$OMPSS_DL_DIR"/nanox-0.15/install
+export MERCURIUM_SRC_DIR="\$OMPSS_DL_DIR"/mcxx-2.3.0
+export MERCURIUM_PREFIX="\$OMPSS_DL_DIR"/mcxx-2.3.0/install
 
 EOF
     mkdir -p "$OMPSS_DL_DIR"
-    wget -nv https://pm.bsc.es/sites/default/files/ftp/ompss/releases/ompss-17.12.1.tar.gz
-    tar -zxf ompss-17.12.1.tar.gz -C "$OMPSS_DL_DIR" --strip-components 1
-    rm -rf ompss-17.12.1.tar.gz
+    wget -nv https://pm.bsc.es/ftp/ompss/releases/ompss-19.06.tar.gz
+    tar -zxf ompss-19.06.tar.gz -C "$OMPSS_DL_DIR" --strip-components 1
+    rm -rf ompss-19.06.tar.gz
 fi
 
 if [[ $USE_OMPSS2 -eq 1 ]]; then

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -252,10 +252,10 @@ EOF
 
 EOF
 
-    wget https://github.com/chapel-lang/chapel/releases/download/1.22.1/chapel-1.22.1.tar.gz
+    wget https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz
     mkdir "$CHPL_HOME"
-    tar xfz chapel-1.22.1.tar.gz -C "$CHPL_HOME" --strip-components 1
-    rm chapel-1.22.1.tar.gz
+    tar xfz chapel-1.27.0.tar.gz -C "$CHPL_HOME" --strip-components 1
+    rm chapel-1.27.0.tar.gz
 fi
 
 if [[ $USE_X10 -eq 1 ]]; then

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -462,6 +462,7 @@ EOF
     conda create -y -n myenv python=3.7 cffi tensorflow=2.1.0
     conda activate myenv
     # Hack: Try to install via pip to avoid compiler version incompatibility
+    # Elliott: I turned this off to fix CI, but it may be required to make deployment to supercomputers work (i.e., it may need to be conditional on CI)
     # pip install -q tensorflow==2.1.0
 fi)
 

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -318,7 +318,7 @@ export BOOST_SRC_DIR="\$OMPSS2_DL_DIR"/boost_1_68_0
 
 EOF
     mkdir -p "$OMPSS2_DL_DIR"
-    git clone -b 2020.06 --depth 1 https://github.com/bsc-pm/ompss-2-releases.git "$OMPSS2_DL_DIR/ompss2-release"
+    git clone -b 2021.11.1 --depth 1 https://github.com/bsc-pm/ompss-2-releases.git "$OMPSS2_DL_DIR/ompss2-release"
     # Note: don't initialize llvm submodule, it's large and not needed
     for m in nanos6 mcxx; do
         git -C "$OMPSS2_DL_DIR/ompss2-release" submodule update --init --recursive --depth 1 $m

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -426,9 +426,9 @@ EOF
     tar xfz zsh-5.5.1.tar.gz -C "$SWIFT_DIR"
     rm zsh-5.5.1.tar.gz
 
-    wget -nv http://swift-lang.github.io/swift-t-downloads/1.4/swift-t-1.4.3.tar.gz
-    tar xfz swift-t-1.4.3.tar.gz -C "$SWIFT_DIR"
-    rm swift-t-1.4.3.tar.gz
+    wget -nv http://swift-lang.github.io/swift-t-downloads/1.5/swift-t-1.5.0.tar.gz
+    tar xfz swift-t-1.5.0.tar.gz -C "$SWIFT_DIR"
+    rm swift-t-1.5.0.tar.gz
 fi
 
 (if [[ $USE_TENSORFLOW -eq 1 ]]; then

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -128,13 +128,7 @@ export USE_PYTHON=\$USE_PYGION
 export USE_LIBDL=\$USE_PYGION
 
 EOF
-    if [[ $USE_REALM -eq 1 ]]; then
-        git clone -b subgraph https://gitlab.com/StanfordLegion/legion.git "$LEGION_DIR"
-    elif [[ $USE_PYGION -eq 1 ]]; then
-        git clone -b regent-python-ctl https://gitlab.com/StanfordLegion/legion.git "$LEGION_DIR"
-    else
-        git clone -b control_replication https://gitlab.com/StanfordLegion/legion.git "$LEGION_DIR"
-    fi
+    git clone -b control_replication https://gitlab.com/StanfordLegion/legion.git "$LEGION_DIR"
 fi
 
 (if [[ $USE_PYGION -eq 1 ]]; then

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -218,7 +218,7 @@ if [[ $USE_CHAPEL -eq 1 ]]; then
     cat >>deps/env.sh <<EOF
 export CHPL_HOME="\$TASKBENCH_DEPS_DIR"/chapel
 export CHPL_HOST_PLATFORM=\$(\$CHPL_HOME/util/chplenv/chpl_platform.py)
-export CHPL_LLVM=llvm
+export CHPL_LLVM=bundled
 export CHPL_TARGET_CPU=native
 # export CHPL_QTHREAD_SCHEDULER=distrib # or sherwood # Enables Chapel work stealing scheduler
 # Note: distrib scheduler needs QTHREAD_STEAL_RATIO=8 set at runtime
@@ -237,9 +237,9 @@ export CHPL_GASNET_MORE_CFG_OPTIONS=$CHPL_GASNET_MORE_CFG_OPTIONS
 EOF
     fi
 
-    if [[ -n $TRAVIS ]]; then
+    if [[ -n $GITHUB_ACTIONS ]]; then
         cat >>deps/env.sh <<EOF
-# overrides to make Travis fast
+# overrides to make CI fast
 export CHPL_TASKS=fifo
 # export CHPL_MEM=cstdlib # FIXME: Breaks input size array
 export CHPL_GMP=none

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -459,11 +459,10 @@ EOF
     rm Miniconda3-latest-Linux-x86_64.sh
     conda update -y conda
     source $CONDA_PREFIX/etc/profile.d/conda.sh
-    conda create -y -n myenv python=3.7 cffi
+    conda create -y -n myenv python=3.7 cffi tensorflow=2.1.0
     conda activate myenv
     # Hack: Try to install via pip to avoid compiler version incompatibility
-    # conda install -y tensorflow
-    pip install -q tensorflow==2.1.0
+    # pip install -q tensorflow==2.1.0
 fi)
 
 (if [[ $USE_DASK -eq 1 ]]; then

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -112,7 +112,7 @@ export HWLOC_SRC_DIR=$HWLOC_DL_DIR/hwloc-1.11.10
 export HWLOC_DIR=$HWLOC_DL_DIR/install
 
 EOF
-    wget https://download.open-mpi.org/release/hwloc/v1.11/hwloc-1.11.10.tar.gz
+    wget -nv https://download.open-mpi.org/release/hwloc/v1.11/hwloc-1.11.10.tar.gz
     mkdir -p "$HWLOC_DL_DIR"
     tar -zxf hwloc-1.11.10.tar.gz -C "$HWLOC_DL_DIR"
     rm -rf hwloc-1.11.10.tar.gz
@@ -156,7 +156,7 @@ EOF
 
     source "$PYGION_DIR"/env.sh
 
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     bash Miniconda3-latest-Linux-x86_64.sh -b -p "$CONDA_PREFIX"
     rm Miniconda3-latest-Linux-x86_64.sh
     conda update -y conda
@@ -171,8 +171,8 @@ export STARPU_SRC_DIR="\$STARPU_DL_DIR"/starpu-1.3.4
 export STARPU_DIR="\$STARPU_DL_DIR"
 
 EOF
-    #wget http://starpu.gforge.inria.fr/files/starpu-1.2.4/starpu-1.2.4.tar.gz
-    wget https://files.inria.fr/starpu/starpu-1.3.4/starpu-1.3.4.tar.gz
+    #wget -nv http://starpu.gforge.inria.fr/files/starpu-1.2.4/starpu-1.2.4.tar.gz
+    wget -nv https://files.inria.fr/starpu/starpu-1.3.4/starpu-1.3.4.tar.gz
     mkdir -p "$STARPU_DL_DIR"
     tar -zxf starpu-1.3.4.tar.gz -C "$STARPU_DL_DIR"
     rm starpu-1.3.4.tar.gz
@@ -204,7 +204,7 @@ export CHARM_SMP_DIR="\$TASKBENCH_DEPS_DIR"/charm++_smp
 EOF
     mkdir "$CHARM_DIR"
     mkdir "$CHARM_SMP_DIR"
-    wget https://charm.cs.illinois.edu/distrib/charm-6.9.0.tar.gz
+    wget -nv https://charm.cs.illinois.edu/distrib/charm-6.9.0.tar.gz
     tar xfz charm-6.9.0.tar.gz -C "$CHARM_DIR" --strip-components 1
     tar xfz charm-6.9.0.tar.gz -C "$CHARM_SMP_DIR" --strip-components 1
     rm charm-6.9.0.tar.gz
@@ -252,7 +252,7 @@ EOF
 
 EOF
 
-    wget https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz
+    wget -nv https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz
     mkdir "$CHPL_HOME"
     tar xfz chapel-1.27.0.tar.gz -C "$CHPL_HOME" --strip-components 1
     rm chapel-1.27.0.tar.gz
@@ -281,7 +281,7 @@ EOF
     tar -zxf jdk-8u131-linux-x64.tar.gz -C "$X10_DIR"
     rm jdk-8u131-linux-x64.tar.gz
 
-    wget "$APACHE_MIRROR"/ant/binaries/apache-ant-1.10.7-bin.tar.gz
+    wget -nv "$APACHE_MIRROR"/ant/binaries/apache-ant-1.10.7-bin.tar.gz
     tar xfz apache-ant-1.10.7-bin.tar.gz -C "$X10_DIR"
     rm apache-ant-1.10.7-bin.tar.gz
 
@@ -302,7 +302,7 @@ export MERCURIUM_PREFIX="\$OMPSS_DL_DIR"/mcxx-2.1.0/install
 
 EOF
     mkdir -p "$OMPSS_DL_DIR"
-    wget https://pm.bsc.es/sites/default/files/ftp/ompss/releases/ompss-17.12.1.tar.gz
+    wget -nv https://pm.bsc.es/sites/default/files/ftp/ompss/releases/ompss-17.12.1.tar.gz
     tar -zxf ompss-17.12.1.tar.gz -C "$OMPSS_DL_DIR" --strip-components 1
     rm -rf ompss-17.12.1.tar.gz
 fi
@@ -324,7 +324,7 @@ EOF
         git -C "$OMPSS2_DL_DIR/ompss2-release" submodule update --init --recursive --depth 1 $m
     done
     
-    # wget https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz
+    # wget -nv https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz
     # tar -zxf boost_1_68_0.tar.gz -C "$OMPSS2_DL_DIR"
     # rm -rf boost_1_68_0.tar.gz
     cat /usr/include/boost/version.hpp | grep "BOOST_LIB_VERSION"
@@ -360,12 +360,12 @@ EOF
     rm jdk-8u131-linux-x64.tar.gz
 
     # Spark 2.3.0
-    wget "$APACHE_MIRROR"/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz #spark-shell doesn't work without hadoop
+    wget -nv "$APACHE_MIRROR"/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz #spark-shell doesn't work without hadoop
     tar -zxf spark-2.3.0-bin-hadoop2.7.tgz -C "$SPARK_DIR" #didn't add to path-put full paths in emtg script
     rm spark-2.3.0-bin-hadoop2.7.tgz
 
     # SWIG 3.0.12
-    wget $SOURCEFORGE_MIRROR/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz
+    wget -nv $SOURCEFORGE_MIRROR/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz
     tar -zxf swig-3.0.12.tar.gz -C "$SPARK_DIR"
     rm swig-3.0.12.tar.gz
 
@@ -399,33 +399,33 @@ export ANT_HOME="\$SWIFT_DIR"/ant
 export PATH="\$ANT_HOME"/bin:"\$PATH"
 EOF
 
-    wget $SOURCEFORGE_MIRROR/tcl/tcl8.6.8-src.tar.gz
+    wget -nv $SOURCEFORGE_MIRROR/tcl/tcl8.6.8-src.tar.gz
     tar xfz tcl8.6.8-src.tar.gz -C "$SWIFT_DIR"
     rm tcl8.6.8-src.tar.gz
 
-    wget $SOURCEFORGE_MIRROR/swig/swig-3.0.12.tar.gz
+    wget -nv $SOURCEFORGE_MIRROR/swig/swig-3.0.12.tar.gz
     tar xfz swig-3.0.12.tar.gz -C "$SWIFT_DIR"
     rm swig-3.0.12.tar.gz
 
-    wget https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz
+    wget -nv https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz
     mkdir "$SWIFT_DIR"/java
     tar xfz openjdk-10.0.2_linux-x64_bin.tar.gz -C "$SWIFT_DIR"/java --strip-components=1
     rm openjdk-10.0.2_linux-x64_bin.tar.gz
 
-    wget "$APACHE_MIRROR"/ant/binaries/apache-ant-1.10.7-bin.tar.gz
+    wget -nv "$APACHE_MIRROR"/ant/binaries/apache-ant-1.10.7-bin.tar.gz
     mkdir "$SWIFT_DIR"/ant
     tar xfz apache-ant-1.10.7-bin.tar.gz -C "$SWIFT_DIR"/ant --strip-components=1
     rm apache-ant-1.10.7-bin.tar.gz
 
-    wget https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.1.tar.gz
+    wget -nv https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.1.tar.gz
     tar xfz ncurses-6.1.tar.gz -C "$SWIFT_DIR"
     rm ncurses-6.1.tar.gz
 
-    wget $SOURCEFORGE_MIRROR/zsh/5.5.1/zsh-5.5.1.tar.gz
+    wget -nv $SOURCEFORGE_MIRROR/zsh/5.5.1/zsh-5.5.1.tar.gz
     tar xfz zsh-5.5.1.tar.gz -C "$SWIFT_DIR"
     rm zsh-5.5.1.tar.gz
 
-    wget http://swift-lang.github.io/swift-t-downloads/1.4/swift-t-1.4.tar.gz
+    wget -nv http://swift-lang.github.io/swift-t-downloads/1.4/swift-t-1.4.tar.gz
     tar xfz swift-t-1.4.tar.gz -C "$SWIFT_DIR"
     rm swift-t-1.4.tar.gz
 fi
@@ -453,7 +453,7 @@ source "\$CONDA_PREFIX"/etc/profile.d/conda.sh
 conda activate myenv
 EOF
 
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     bash Miniconda3-latest-Linux-x86_64.sh -b -p "$CONDA_PREFIX"
     rm Miniconda3-latest-Linux-x86_64.sh
     conda update -y conda
@@ -482,7 +482,7 @@ EOF
 
     source "$DASK_DIR"/env.sh
 
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     bash Miniconda3-latest-Linux-x86_64.sh -b -p "$CONDA_PREFIX"
     rm Miniconda3-latest-Linux-x86_64.sh
     conda update -y conda

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -426,9 +426,9 @@ EOF
     tar xfz zsh-5.5.1.tar.gz -C "$SWIFT_DIR"
     rm zsh-5.5.1.tar.gz
 
-    wget -nv http://swift-lang.github.io/swift-t-downloads/1.4/swift-t-1.4.tar.gz
-    tar xfz swift-t-1.4.tar.gz -C "$SWIFT_DIR"
-    rm swift-t-1.4.tar.gz
+    wget -nv http://swift-lang.github.io/swift-t-downloads/1.5/swift-t-1.5.0.tar.gz
+    tar xfz swift-t-1.5.0.tar.gz -C "$SWIFT_DIR"
+    rm swift-t-1.5.0.tar.gz
 fi
 
 (if [[ $USE_TENSORFLOW -eq 1 ]]; then

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -426,9 +426,9 @@ EOF
     tar xfz zsh-5.5.1.tar.gz -C "$SWIFT_DIR"
     rm zsh-5.5.1.tar.gz
 
-    wget -nv http://swift-lang.github.io/swift-t-downloads/1.5/swift-t-1.5.0.tar.gz
-    tar xfz swift-t-1.5.0.tar.gz -C "$SWIFT_DIR"
-    rm swift-t-1.5.0.tar.gz
+    wget -nv http://swift-lang.github.io/swift-t-downloads/1.4/swift-t-1.4.3.tar.gz
+    tar xfz swift-t-1.4.3.tar.gz -C "$SWIFT_DIR"
+    rm swift-t-1.4.3.tar.gz
 fi
 
 (if [[ $USE_TENSORFLOW -eq 1 ]]; then

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -218,6 +218,7 @@ if [[ $USE_CHAPEL -eq 1 ]]; then
     cat >>deps/env.sh <<EOF
 export CHPL_HOME="\$TASKBENCH_DEPS_DIR"/chapel
 export CHPL_HOST_PLATFORM=\$(\$CHPL_HOME/util/chplenv/chpl_platform.py)
+export CHPL_HOST_ARCH=\$(\$CHPL_HOME/util/chplenv/chpl_arch.py)
 export CHPL_LLVM=bundled
 export CHPL_TARGET_CPU=native
 # export CHPL_QTHREAD_SCHEDULER=distrib # or sherwood # Enables Chapel work stealing scheduler

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -322,7 +322,7 @@ terra make_secondary_partition(graph : core.task_graph_t, dset : int, input : in
         nil, 0)
     end
   end
-  return c.legion_logical_partition_create(runtime, context, r, ip)
+  return c.legion_logical_partition_create(runtime, r, ip)
 end
 
 function gcd(a, b)

--- a/test_all.sh
+++ b/test_all.sh
@@ -254,10 +254,10 @@ fi
     export LD_LIBRARY_PATH="$CORE_DIR:$SPARK_PROJ_DIR:$LD_LIBRARY_PATH"
 
     # These tests require a running ssh server that allows
-    # passwordless connections to localhost. On Travis we do this by
+    # passwordless connections to localhost. On CI we do this by
     # setting up a passwordless SSH key. However, these are not
     # changes I'm comfortable making to an arbitrary user's machine.
-    if [[ -n $TRAVIS ]]; then
+    if [[ -n $GITHUB_ACTIONS ]]; then
         ssh-keygen -N "" -f "$HOME/.ssh/id_rsa"
         cat "$HOME/.ssh/id_rsa.pub" >> "$HOME/.ssh/authorized_keys"
         echo "id_rsa.pub:"


### PR DESCRIPTION
Upgrades:

  * OS: Ubuntu 18.04 -> 20.04
  * Chapel: 1.22.1 -> 1.27.0
  * Legion: `control_replication` on all variants, unpinned Terra (now pinned by `setup_env.py`)

The following are getting switched off because I wasn't able to figure out to fix them:

  * OmpSs 1 and 2
  * Swift/T