### PR TITLE
Add HPX fork_join_executor implementation for intra-node parallelism 

### DIFF
--- a/get_deps.sh
+++ b/get_deps.sh
@@ -309,7 +309,7 @@ export HPX_INSTALL_ROOT="\$HPX_DIR"/install
 export HWLOC_SRC_DIR="\$HPX_SOURCE_ROOT"/hwloc-2.7.1
 export JEMALLOC_SRC_DIR="\$HPX_SOURCE_ROOT"/jemalloc-5.2.1
 
-export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:\$HPX_INSTALL_ROOT/hpx/lib"
+export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:\$HPX_INSTALL_ROOT/hpx/lib:\$HPX_INSTALL_ROOT/jemalloc/lib"
 EOF
 
     source "$HPX_DIR"/env.sh

--- a/hpx/CMakeLists.txt
+++ b/hpx/CMakeLists.txt
@@ -20,18 +20,35 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 find_package(HPX REQUIRED)
-find_package(MPI REQUIRED)
+find_package(MPI)
 
 include(GNUInstallDirs)
 
 link_directories(${CMAKE_SOURCE_DIR}/../core)
 
-add_executable(hpx_distributed hpx_distributed.cc)
-target_link_libraries(hpx_distributed PUBLIC HPX::hpx HPX::wrap_main MPI::MPI_C core_s)
+# Build hpx_distributed only if MPI is available
+if(MPI_FOUND)
+  add_executable(hpx_distributed hpx_distributed.cc)
+  target_include_directories(hpx_distributed PRIVATE ${CMAKE_SOURCE_DIR}/../core)
+  target_link_libraries(hpx_distributed PUBLIC HPX::hpx HPX::wrap_main MPI::MPI_C core_s)
+  set(INSTALL_TARGETS hpx_distributed)
+  message(STATUS "MPI found - building hpx_distributed")
+else()
+  message(STATUS "MPI not found - skipping hpx_distributed")
+  set(INSTALL_TARGETS "")
+endif()
 
-install(
-  TARGETS hpx_distributed
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+# New fork_join_executor implementation for intra-node parallelism
+add_executable(hpx_task_bench hpx_task_bench.cpp)
+target_include_directories(hpx_task_bench PRIVATE ${CMAKE_SOURCE_DIR}/../core)
+target_link_libraries(hpx_task_bench PUBLIC HPX::hpx HPX::wrap_main core_s)
+list(APPEND INSTALL_TARGETS hpx_task_bench)
+
+if(INSTALL_TARGETS)
+  install(
+    TARGETS ${INSTALL_TARGETS}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
+endif()

--- a/hpx/CMakeLists.txt
+++ b/hpx/CMakeLists.txt
@@ -38,11 +38,11 @@ else()
   set(INSTALL_TARGETS "")
 endif()
 
-# New fork_join_executor implementation for intra-node parallelism
-add_executable(hpx_task_bench hpx_task_bench.cpp)
-target_include_directories(hpx_task_bench PRIVATE ${CMAKE_SOURCE_DIR}/../core)
-target_link_libraries(hpx_task_bench PUBLIC HPX::hpx HPX::wrap_main core_s)
-list(APPEND INSTALL_TARGETS hpx_task_bench)
+# Fork-join executor implementation for intra-node parallelism
+add_executable(hpx_fork_join hpx_fork_join.cc)
+target_include_directories(hpx_fork_join PRIVATE ${CMAKE_SOURCE_DIR}/../core)
+target_link_libraries(hpx_fork_join PUBLIC HPX::hpx HPX::wrap_main core_s)
+list(APPEND INSTALL_TARGETS hpx_fork_join)
 
 if(INSTALL_TARGETS)
   install(

--- a/hpx/hpx_distributed.cc
+++ b/hpx/hpx_distributed.cc
@@ -18,7 +18,6 @@
 #include "../core/core.h"
 #include "hpx/hpx.hpp"
 #include "hpx/hpx_init.hpp"
-
 #include "mpi.h"
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -65,7 +64,6 @@ int hpx_main(int argc, char *argv[])
     double start_time = MPI_Wtime();
 
     for (auto graph : app.graphs) {
-
       long first_point = rank * graph.max_width / n_ranks;
       long last_point = (rank + 1) * graph.max_width / n_ranks - 1;
       long n_points = last_point - first_point + 1;
@@ -150,8 +148,10 @@ int hpx_main(int argc, char *argv[])
       // optimization for certain types, wherein only the boundary cores of a
       // node need to communicate with cores from another nodes, which means the
       // inner cores only use on-node sharing.
-      if (graph.dependence == (RANDOM_NEAREST ||  NEAREST || STENCIL_1D ||
-          STENCIL_1D_PERIODIC || FFT || NO_COMM || TRIVIAL)) {
+      if (graph.dependence == (RANDOM_NEAREST || NEAREST || STENCIL_1D ||
+                               STENCIL_1D_PERIODIC || FFT || NO_COMM ||
+                               TRIVIAL))
+      {
         for (long timestep = 0; timestep < graph.timesteps; ++timestep) {
           long offset = graph.offset_at_timestep(timestep);
           long width = graph.width_at_timestep(timestep);
@@ -161,92 +161,102 @@ int hpx_main(int argc, char *argv[])
           auto &deps = dependencies[dset];
           auto &rev_deps = reverse_dependencies[dset];
 
-          hpx::experimental::for_loop(policy, first_point, last_point+1, [&](int point) {
-            std::vector<MPI_Request> requests;
-            long point_index = point - first_point;
-            auto &point_inputs = inputs[point_index];
-            auto &point_n_inputs = n_inputs[point_index];
-            auto &point_output = outputs[point_index];
-            auto &point_output_new = outputs_new[point_index];
-            auto &point_input_ptr = input_ptr[point_index];
-            auto &point_input_bytes = input_bytes[point_index];
-            auto &point_deps = deps[point_index];
-            auto &point_rev_deps = rev_deps[point_index];
+          hpx::experimental::for_loop(
+              policy, first_point, last_point + 1, [&](int point) {
+                std::vector<MPI_Request> requests;
+                long point_index = point - first_point;
+                auto &point_inputs = inputs[point_index];
+                auto &point_n_inputs = n_inputs[point_index];
+                auto &point_output = outputs[point_index];
+                auto &point_output_new = outputs_new[point_index];
+                auto &point_input_ptr = input_ptr[point_index];
+                auto &point_input_bytes = input_bytes[point_index];
+                auto &point_deps = deps[point_index];
+                auto &point_rev_deps = rev_deps[point_index];
 
-            // Receive
-            point_n_inputs = 0;
-            if (point >= offset && point < offset + width) {
-              for (auto interval : point_deps) {
-                for (long dep = interval.first; dep <= interval.second; ++dep) {
-                  if (dep < last_offset || dep >= last_offset + last_width) {
-                    continue;
-                  }
-                  // Use shared memory for on-node data.
-                  if (first_point <= dep && dep <= last_point) {
-                    auto output = outputs[dep - first_point];
-                    if (timestep % 2 == 0) {
-                      point_inputs[point_n_inputs].assign(output.begin(),
-                                                        output.end());
-                    } else {
-                      auto output_new = outputs_new[dep - first_point];
-                      point_inputs[point_n_inputs].assign(output_new.begin(),
-                                                        output_new.end());
+                // Receive
+                point_n_inputs = 0;
+                if (point >= offset && point < offset + width) {
+                  for (auto interval : point_deps) {
+                    for (long dep = interval.first; dep <= interval.second;
+                         ++dep) {
+                      if (dep < last_offset ||
+                          dep >= last_offset + last_width) {
+                        continue;
+                      }
+                      // Use shared memory for on-node data.
+                      if (first_point <= dep && dep <= last_point) {
+                        auto output = outputs[dep - first_point];
+                        if (timestep % 2 == 0) {
+                          point_inputs[point_n_inputs].assign(output.begin(),
+                                                              output.end());
+                        } else {
+                          auto output_new = outputs_new[dep - first_point];
+                          point_inputs[point_n_inputs].assign(
+                              output_new.begin(), output_new.end());
+                        }
+                      } else {
+                        int from = tag_bits_by_point[dep];
+                        int to = tag_bits_by_point[point];
+                        int tag = (from << 8) | to;
+                        MPI_Request req;
+                        MPI_Irecv(point_inputs[point_n_inputs].data(),
+                                  point_inputs[point_n_inputs].size(), MPI_BYTE,
+                                  rank_by_point[dep], tag, MPI_COMM_WORLD,
+                                  &req);
+                        requests.push_back(req);
+                      }
+                      point_n_inputs++;
                     }
-                  } else {
-                    int from = tag_bits_by_point[dep];
-                    int to = tag_bits_by_point[point];
-                    int tag = (from << 8) | to;
-                    MPI_Request req;
-                    MPI_Irecv(point_inputs[point_n_inputs].data(),
-                              point_inputs[point_n_inputs].size(), MPI_BYTE,
-                              rank_by_point[dep], tag, MPI_COMM_WORLD, &req);
-                    requests.push_back(req);
                   }
-                  point_n_inputs++;
+                }  // receive
+
+                // Send
+                if (point >= last_offset && point < last_offset + last_width) {
+                  for (auto interval : point_rev_deps) {
+                    for (long dep = interval.first; dep <= interval.second;
+                         dep++) {
+                      if (dep < offset || dep >= offset + width ||
+                          (first_point <= dep && dep <= last_point))
+                      {
+                        continue;
+                      }
+                      int from = tag_bits_by_point[point];
+                      int to = tag_bits_by_point[dep];
+                      int tag = (from << 8) | to;
+                      MPI_Request req;
+                      if (timestep % 2 == 0) {
+                        MPI_Isend(point_output.data(), point_output.size(),
+                                  MPI_BYTE, rank_by_point[dep], tag,
+                                  MPI_COMM_WORLD, &req);
+                      } else {
+                        MPI_Isend(point_output_new.data(),
+                                  point_output_new.size(), MPI_BYTE,
+                                  rank_by_point[dep], tag, MPI_COMM_WORLD,
+                                  &req);
+                      }
+                      requests.push_back(req);
+                    }
+                  }
+                }  // send
+
+                MPI_Waitall(requests.size(), requests.data(),
+                            MPI_STATUSES_IGNORE);
+
+                if (timestep % 2 == 0) {
+                  graph.execute_point(
+                      timestep, point, point_output_new.data(),
+                      point_output_new.size(), point_input_ptr.data(),
+                      point_input_bytes.data(), point_n_inputs,
+                      scratch_ptr + scratch_bytes * point_index, scratch_bytes);
+                } else {
+                  graph.execute_point(
+                      timestep, point, point_output.data(), point_output.size(),
+                      point_input_ptr.data(), point_input_bytes.data(),
+                      point_n_inputs, scratch_ptr + scratch_bytes * point_index,
+                      scratch_bytes);
                 }
-              }
-            }  // receive
-
-            // Send
-            if (point >= last_offset && point < last_offset + last_width) {
-              for (auto interval : point_rev_deps) {
-                for (long dep = interval.first; dep <= interval.second; dep++) {
-                  if (dep < offset || dep >= offset + width ||
-                      (first_point <= dep && dep <= last_point)) {
-                    continue;
-                  }
-                  int from = tag_bits_by_point[point];
-                  int to = tag_bits_by_point[dep];
-                  int tag = (from << 8) | to;
-                  MPI_Request req;
-                  if (timestep % 2 == 0) {
-                      MPI_Isend(point_output.data(), point_output.size(), MPI_BYTE,
-                            rank_by_point[dep], tag, MPI_COMM_WORLD, &req);
-                  } else {
-                      MPI_Isend(point_output_new.data(), point_output_new.size(), MPI_BYTE,
-                            rank_by_point[dep], tag, MPI_COMM_WORLD, &req);
-                  }
-                  requests.push_back(req);
-                }
-              }
-            }  // send
-
-            MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
-
-            if (timestep % 2 == 0) {
-                graph.execute_point(timestep, point, point_output_new.data(),
-                                point_output_new.size(), point_input_ptr.data(),
-                                point_input_bytes.data(), point_n_inputs,
-                                scratch_ptr + scratch_bytes * point_index,
-                                scratch_bytes);
-            } else {
-                graph.execute_point(timestep, point, point_output.data(),
-                                point_output.size(), point_input_ptr.data(),
-                                point_input_bytes.data(), point_n_inputs,
-                                scratch_ptr + scratch_bytes * point_index,
-                                scratch_bytes);
-            }
-          });  // one hpx for loop 
+              });  // one hpx for loop
         }
       } else {
         for (long timestep = 0; timestep < graph.timesteps; ++timestep) {
@@ -300,7 +310,8 @@ int hpx_main(int argc, char *argv[])
               for (auto interval : point_rev_deps) {
                 for (long dep = interval.first; dep <= interval.second; dep++) {
                   if (dep < offset || dep >= offset + width ||
-                      (first_point <= dep && dep <= last_point)) {
+                      (first_point <= dep && dep <= last_point))
+                  {
                     continue;
                   }
                   int from = tag_bits_by_point[point];
@@ -313,7 +324,7 @@ int hpx_main(int argc, char *argv[])
                 }
               }
             }  // send
-          }  
+          }
 
           MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
 
@@ -332,11 +343,11 @@ int hpx_main(int argc, char *argv[])
                                   point_input_bytes.data(), point_n_inputs,
                                   scratch_ptr + scratch_bytes * point_index,
                                   scratch_bytes);
-            });  
+            });
           }
-        } 
-      } 
-    }    // for graphs loop
+        }
+      }
+    }  // for graphs loop
 
     double stop_time = MPI_Wtime();
     elapsed_time = stop_time - start_time;
@@ -354,7 +365,8 @@ int main(int argc, char *argv[])
 {
   // all ranks run their main function
   std::vector<std::string> const cfg = {
-      "hpx.run_hpx_main!=1", "--hpx:ini=hpx.commandline.allow_unknown!=1",
+      "hpx.run_hpx_main!=1",
+      "--hpx:ini=hpx.commandline.allow_unknown!=1",
       "--hpx:ini=hpx.commandline.aliasing!=0",
       //"--hpx:ini=hpx.stacks.small_size!=0x20000"
   };

--- a/hpx/hpx_distributed.cc
+++ b/hpx/hpx_distributed.cc
@@ -30,19 +30,10 @@ int hpx_main(int argc, char *argv[])
   App app(argc, argv);
   if (rank == 0) app.display();
 
-  int chunk_size =
-      app.graphs[0].max_width / (n_ranks * hpx::get_os_thread_count());
-
-  hpx::execution::experimental::static_chunk_size cs(chunk_size);
-
-  using executor = hpx::execution::experimental::fork_join_executor;
-  executor exec(hpx::threads::thread_priority::normal,
-                hpx::threads::thread_stacksize::small_,
-                chunk_size == 1 ? executor::loop_schedule::static_
-                                : executor::loop_schedule::dynamic,
-                std::chrono::microseconds(100));
-
-  auto policy = hpx::execution::par.on(exec).with(cs);
+  // Use the default parallel executor (task-based) instead of fork_join_executor.
+  // fork_join_executor busy-spins all HPX threads, starving OpenMPI's async
+  // progress thread and causing MPI_Waitall to hang nondeterministically.
+  auto policy = hpx::execution::par;
 
   std::vector<std::vector<char> > scratch;
 
@@ -148,10 +139,12 @@ int hpx_main(int argc, char *argv[])
       // optimization for certain types, wherein only the boundary cores of a
       // node need to communicate with cores from another nodes, which means the
       // inner cores only use on-node sharing.
-      if (graph.dependence == (RANDOM_NEAREST || NEAREST || STENCIL_1D ||
-                               STENCIL_1D_PERIODIC || FFT || NO_COMM ||
-                               TRIVIAL))
-      {
+      auto is_optimized = [](DependenceType d) {
+        return d == RANDOM_NEAREST || d == NEAREST || d == STENCIL_1D ||
+               d == STENCIL_1D_PERIODIC || d == FFT || d == NO_COMM ||
+               d == TRIVIAL;
+      };
+      if (is_optimized(graph.dependence)) {
         for (long timestep = 0; timestep < graph.timesteps; ++timestep) {
           long offset = graph.offset_at_timestep(timestep);
           long width = graph.width_at_timestep(timestep);
@@ -180,18 +173,18 @@ int hpx_main(int argc, char *argv[])
                   for (auto interval : point_deps) {
                     for (long dep = interval.first; dep <= interval.second;
                          ++dep) {
-                      if (dep < last_offset ||
-                          dep >= last_offset + last_width) {
+                      if (dep < last_offset || dep >= last_offset + last_width)
+                      {
                         continue;
                       }
                       // Use shared memory for on-node data.
                       if (first_point <= dep && dep <= last_point) {
-                        auto output = outputs[dep - first_point];
                         if (timestep % 2 == 0) {
+                          auto &output = outputs[dep - first_point];
                           point_inputs[point_n_inputs].assign(output.begin(),
                                                               output.end());
                         } else {
-                          auto output_new = outputs_new[dep - first_point];
+                          auto &output_new = outputs_new[dep - first_point];
                           point_inputs[point_n_inputs].assign(
                               output_new.begin(), output_new.end());
                         }
@@ -368,7 +361,9 @@ int main(int argc, char *argv[])
       "hpx.run_hpx_main!=1",
       "--hpx:ini=hpx.commandline.allow_unknown!=1",
       "--hpx:ini=hpx.commandline.aliasing!=0",
-      //"--hpx:ini=hpx.stacks.small_size!=0x20000"
+      // Disable HPX's MPI parcelport so it does not interfere with the
+      // application-level MPI calls (tag collisions / progress-thread contention).
+      "--hpx:ini=hpx.parcel.mpi.enable=0",
   };
 
   // Init MPI

--- a/hpx/hpx_distributed.cc
+++ b/hpx/hpx_distributed.cc
@@ -173,8 +173,8 @@ int hpx_main(int argc, char *argv[])
                   for (auto interval : point_deps) {
                     for (long dep = interval.first; dep <= interval.second;
                          ++dep) {
-                      if (dep < last_offset || dep >= last_offset + last_width)
-                      {
+                      if (dep < last_offset ||
+                          dep >= last_offset + last_width) {
                         continue;
                       }
                       // Use shared memory for on-node data.

--- a/hpx/hpx_distributed.cc
+++ b/hpx/hpx_distributed.cc
@@ -34,7 +34,7 @@ int hpx_main(int argc, char *argv[])
   int chunk_size =
       app.graphs[0].max_width / (n_ranks * hpx::get_os_thread_count());
 
-  hpx::execution::static_chunk_size cs(chunk_size);
+  hpx::execution::experimental::static_chunk_size cs(chunk_size);
 
   using executor = hpx::execution::experimental::fork_join_executor;
   executor exec(hpx::threads::thread_priority::normal,
@@ -161,7 +161,7 @@ int hpx_main(int argc, char *argv[])
           auto &deps = dependencies[dset];
           auto &rev_deps = reverse_dependencies[dset];
 
-          hpx::for_loop(policy, first_point, last_point+1, [&](int point) {
+          hpx::experimental::for_loop(policy, first_point, last_point+1, [&](int point) {
             std::vector<MPI_Request> requests;
             long point_index = point - first_point;
             auto &point_inputs = inputs[point_index];
@@ -320,7 +320,7 @@ int hpx_main(int argc, char *argv[])
           long start = std::max(first_point, offset);
           long end = std::min(last_point + 1, offset + width);
           if (start < end) {
-            hpx::for_loop(policy, start, end, [&](int point) {
+            hpx::experimental::for_loop(policy, start, end, [&](int point) {
               long point_index = point - first_point;
               auto &point_input_ptr = input_ptr[point_index];
               auto &point_input_bytes = input_bytes[point_index];

--- a/hpx/hpx_fork_join.cc
+++ b/hpx/hpx_fork_join.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 Nanmiao Wu, Nikunj Gupta, and Patrick Diehl
+/* Copyright 2026 Nanmiao Wu, Nikunj Gupta, Patrick Diehl, and Pratyksh Gupta
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hpx/hpx_task_bench.cpp
+++ b/hpx/hpx_task_bench.cpp
@@ -1,0 +1,505 @@
+/* Copyright 2021 Nanmiao Wu, Nikunj Gupta, and Patrick Diehl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "core.h"
+#include "hpx/hpx.hpp"
+#include "hpx/hpx_init.hpp"
+
+#ifdef HAVE_MPI
+#include "mpi.h"
+#else
+#define MPI_COMM_WORLD 0
+#define MPI_BYTE 0
+#define MPI_STATUSES_IGNORE 0
+#define MPI_THREAD_MULTIPLE 0
+typedef int MPI_Request;
+inline void MPI_Comm_size(int, int* s)
+{
+    *s = 1;
+}
+inline void MPI_Comm_rank(int, int* r)
+{
+    *r = 0;
+}
+inline void MPI_Barrier(int) {}
+inline double MPI_Wtime()
+{
+    static auto start = std::chrono::steady_clock::now();
+    auto now = std::chrono::steady_clock::now();
+    return std::chrono::duration<double>(now - start).count();
+}
+inline void MPI_Init_thread(int*, char***, int, int* p)
+{
+    *p = MPI_THREAD_MULTIPLE;
+}
+inline void MPI_Finalize() {}
+
+inline void MPI_Irecv(void*, int, int, int, int, int, MPI_Request*)
+{
+    std::abort();
+}
+inline void MPI_Isend(void*, int, int, int, int, int, MPI_Request*)
+{
+    std::abort();
+}
+inline void MPI_Waitall(int, MPI_Request*, int) {}
+#endif
+
+int hpx_main(int argc, char* argv[])
+{
+    int n_ranks, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &n_ranks);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    App app(argc, argv);
+    if (rank == 0)
+        app.display();
+
+    int chunk_size =
+        app.graphs[0].max_width / (n_ranks * hpx::get_os_thread_count());
+
+    if (chunk_size < 1)
+        chunk_size = 1;
+
+    hpx::execution::experimental::static_chunk_size cs(chunk_size);
+
+    using executor = hpx::execution::experimental::fork_join_executor;
+    executor exec(hpx::threads::thread_priority::normal,
+        hpx::threads::thread_stacksize::small_,
+        chunk_size == 1 ? executor::loop_schedule::static_ :
+                          executor::loop_schedule::dynamic,
+        std::chrono::microseconds(100));
+
+    auto policy = hpx::execution::par.on(exec).with(cs);
+
+    std::vector<std::vector<char>> scratch;
+
+    for (auto graph : app.graphs)
+    {
+        long first_point = rank * graph.max_width / n_ranks;
+        long last_point = (rank + 1) * graph.max_width / n_ranks - 1;
+        long n_points = last_point - first_point + 1;
+
+        size_t scratch_bytes = graph.scratch_bytes_per_task;
+        scratch.emplace_back(scratch_bytes * n_points);
+        TaskGraph::prepare_scratch(
+            scratch.back().data(), scratch.back().size());
+    }
+
+    double elapsed_time = 0.0;
+
+    for (int iter = 0; iter < 2; ++iter)
+    {
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        double start_time = MPI_Wtime();
+
+        for (auto graph : app.graphs)
+        {
+            long first_point = rank * graph.max_width / n_ranks;
+            long last_point = (rank + 1) * graph.max_width / n_ranks - 1;
+            long n_points = last_point - first_point + 1;
+
+            size_t scratch_bytes = graph.scratch_bytes_per_task;
+            char* scratch_ptr = scratch[graph.graph_index].data();
+
+            std::vector<int> rank_by_point(graph.max_width);
+            std::vector<int> tag_bits_by_point(graph.max_width);
+
+            for (int r = 0; r < n_ranks; ++r)
+            {
+                long r_first_point = r * graph.max_width / n_ranks;
+                long r_last_point = (r + 1) * graph.max_width / n_ranks - 1;
+                for (long p = r_first_point; p <= r_last_point; ++p)
+                {
+                    rank_by_point[p] = r;
+                    tag_bits_by_point[p] = p - r_first_point;
+                    assert((tag_bits_by_point[p] & ~0x7F) == 0);
+                }
+            }
+
+            long max_deps = 0;
+            for (long dset = 0; dset < graph.max_dependence_sets(); ++dset)
+            {
+                for (long point = first_point; point <= last_point; ++point)
+                {
+                    long deps = 0;
+                    for (auto interval : graph.dependencies(dset, point))
+                    {
+                        deps += interval.second - interval.first + 1;
+                    }
+                    max_deps = std::max(max_deps, deps);
+                }
+            }
+
+            std::vector<std::vector<std::vector<char>>> inputs(n_points);
+            std::vector<std::vector<char const*>> input_ptr(n_points);
+            std::vector<std::vector<size_t>> input_bytes(n_points);
+            std::vector<long> n_inputs(n_points);
+            std::vector<std::vector<char>> outputs(n_points);
+            std::vector<std::vector<char>> outputs_new(n_points);
+
+            for (long point = first_point; point <= last_point; ++point)
+            {
+                long point_index = point - first_point;
+
+                auto& point_inputs = inputs[point_index];
+                auto& point_input_ptr = input_ptr[point_index];
+                auto& point_input_bytes = input_bytes[point_index];
+
+                point_inputs.resize(max_deps);
+                point_input_ptr.resize(max_deps);
+                point_input_bytes.resize(max_deps);
+
+                for (long dep = 0; dep < max_deps; ++dep)
+                {
+                    point_inputs[dep].resize(graph.output_bytes_per_task);
+                    point_input_ptr[dep] = point_inputs[dep].data();
+                    point_input_bytes[dep] = point_inputs[dep].size();
+                }
+
+                auto& point_outputs = outputs[point_index];
+                point_outputs.resize(graph.output_bytes_per_task);
+
+                auto& point_outputs_new = outputs_new[point_index];
+                point_outputs_new.resize(graph.output_bytes_per_task);
+            }
+
+            std::vector<std::vector<std::vector<std::pair<long, long>>>>
+                dependencies(graph.max_dependence_sets());
+            std::vector<std::vector<std::vector<std::pair<long, long>>>>
+                reverse_dependencies(graph.max_dependence_sets());
+            for (long dset = 0; dset < graph.max_dependence_sets(); ++dset)
+            {
+                dependencies[dset].resize(n_points);
+                reverse_dependencies[dset].resize(n_points);
+
+                for (long point = first_point; point <= last_point; ++point)
+                {
+                    long point_index = point - first_point;
+
+                    dependencies[dset][point_index] =
+                        graph.dependencies(dset, point);
+                    reverse_dependencies[dset][point_index] =
+                        graph.reverse_dependencies(dset, point);
+                }
+            }
+
+            auto is_optimized = [&](DependenceType d) {
+                return d == RANDOM_NEAREST || d == NEAREST || d == STENCIL_1D ||
+                    d == STENCIL_1D_PERIODIC || d == FFT || d == NO_COMM ||
+                    d == TRIVIAL;
+            };
+
+            if (is_optimized(graph.dependence))
+            {
+                for (long timestep = 0; timestep < graph.timesteps; ++timestep)
+                {
+                    long offset = graph.offset_at_timestep(timestep);
+                    long width = graph.width_at_timestep(timestep);
+                    long last_offset = graph.offset_at_timestep(timestep - 1);
+                    long last_width = graph.width_at_timestep(timestep - 1);
+                    long dset = graph.dependence_set_at_timestep(timestep);
+                    auto& deps = dependencies[dset];
+                    auto& rev_deps = reverse_dependencies[dset];
+
+                    hpx::experimental::for_loop(
+                        policy, first_point, last_point + 1, [&](int point) {
+                            std::vector<MPI_Request> requests;
+                            long point_index = point - first_point;
+                            auto& point_n_inputs = n_inputs[point_index];
+                            auto& point_output = outputs[point_index];
+                            auto& point_output_new = outputs_new[point_index];
+                            auto& point_input_ptr = input_ptr[point_index];
+                            auto& point_input_bytes = input_bytes[point_index];
+
+                            point_n_inputs = 0;
+                            if (point >= offset && point < offset + width)
+                            {
+                                auto& point_inputs = inputs[point_index];
+                                auto& point_deps = deps[point_index];
+                                for (auto interval : point_deps)
+                                {
+                                    for (long dep = interval.first;
+                                        dep <= interval.second; ++dep)
+                                    {
+                                        if (dep < last_offset ||
+                                            dep >= last_offset + last_width)
+                                        {
+                                            continue;
+                                        }
+                                        if (first_point <= dep &&
+                                            dep <= last_point)
+                                        {
+                                            if (timestep % 2 == 0)
+                                            {
+                                                auto& output =
+                                                    outputs[dep - first_point];
+                                                point_inputs[point_n_inputs]
+                                                    .assign(output.begin(),
+                                                        output.end());
+                                            }
+                                            else
+                                            {
+                                                auto& output_new =
+                                                    outputs_new[dep -
+                                                        first_point];
+                                                point_inputs[point_n_inputs]
+                                                    .assign(output_new.begin(),
+                                                        output_new.end());
+                                            }
+                                        }
+                                        else
+                                        {
+                                            int from = tag_bits_by_point[dep];
+                                            int to = tag_bits_by_point[point];
+                                            int tag = (from << 8) | to;
+                                            MPI_Request req;
+                                            MPI_Irecv(
+                                                point_inputs[point_n_inputs]
+                                                    .data(),
+                                                point_inputs[point_n_inputs]
+                                                    .size(),
+                                                MPI_BYTE, rank_by_point[dep],
+                                                tag, MPI_COMM_WORLD, &req);
+                                            requests.push_back(req);
+                                        }
+                                        point_n_inputs++;
+                                    }
+                                }
+                            }
+
+                            if (point >= last_offset &&
+                                point < last_offset + last_width)
+                            {
+                                auto& point_rev_deps = rev_deps[point_index];
+                                for (auto interval : point_rev_deps)
+                                {
+                                    for (long dep = interval.first;
+                                        dep <= interval.second; dep++)
+                                    {
+                                        if (dep < offset ||
+                                            dep >= offset + width ||
+                                            (first_point <= dep &&
+                                                dep <= last_point))
+                                        {
+                                            continue;
+                                        }
+                                        int from = tag_bits_by_point[point];
+                                        int to = tag_bits_by_point[dep];
+                                        int tag = (from << 8) | to;
+                                        MPI_Request req;
+                                        if (timestep % 2 == 0)
+                                        {
+                                            MPI_Isend(point_output.data(),
+                                                point_output.size(), MPI_BYTE,
+                                                rank_by_point[dep], tag,
+                                                MPI_COMM_WORLD, &req);
+                                        }
+                                        else
+                                        {
+                                            MPI_Isend(point_output_new.data(),
+                                                point_output_new.size(),
+                                                MPI_BYTE, rank_by_point[dep],
+                                                tag, MPI_COMM_WORLD, &req);
+                                        }
+                                        requests.push_back(req);
+                                    }
+                                }
+                            }
+
+                            MPI_Waitall(requests.size(), requests.data(),
+                                MPI_STATUSES_IGNORE);
+
+                            if (timestep % 2 == 0)
+                            {
+                                graph.execute_point(timestep, point,
+                                    point_output_new.data(),
+                                    point_output_new.size(),
+                                    point_input_ptr.data(),
+                                    point_input_bytes.data(), point_n_inputs,
+                                    scratch_ptr + scratch_bytes * point_index,
+                                    scratch_bytes);
+                            }
+                            else
+                            {
+                                graph.execute_point(timestep, point,
+                                    point_output.data(), point_output.size(),
+                                    point_input_ptr.data(),
+                                    point_input_bytes.data(), point_n_inputs,
+                                    scratch_ptr + scratch_bytes * point_index,
+                                    scratch_bytes);
+                            }
+                        });
+                }
+            }
+            else
+            {
+                for (long timestep = 0; timestep < graph.timesteps; ++timestep)
+                {
+                    long offset = graph.offset_at_timestep(timestep);
+                    long width = graph.width_at_timestep(timestep);
+                    long last_offset = graph.offset_at_timestep(timestep - 1);
+                    long last_width = graph.width_at_timestep(timestep - 1);
+                    long dset = graph.dependence_set_at_timestep(timestep);
+                    auto& deps = dependencies[dset];
+                    auto& rev_deps = reverse_dependencies[dset];
+
+                    std::vector<MPI_Request> requests;
+                    for (long point = first_point; point <= last_point; ++point)
+                    {
+                        long point_index = point - first_point;
+                        auto& point_n_inputs = n_inputs[point_index];
+                        auto& point_output = outputs[point_index];
+
+                        point_n_inputs = 0;
+                        if (point >= offset && point < offset + width)
+                        {
+                            auto& point_inputs = inputs[point_index];
+                            auto& point_deps = deps[point_index];
+                            for (auto interval : point_deps)
+                            {
+                                for (long dep = interval.first;
+                                    dep <= interval.second; ++dep)
+                                {
+                                    if (dep < last_offset ||
+                                        dep >= last_offset + last_width)
+                                    {
+                                        continue;
+                                    }
+                                    if (first_point <= dep && dep <= last_point)
+                                    {
+                                        auto& output =
+                                            outputs[dep - first_point];
+                                        point_inputs[point_n_inputs].assign(
+                                            output.begin(), output.end());
+                                    }
+                                    else
+                                    {
+                                        int from = tag_bits_by_point[dep];
+                                        int to = tag_bits_by_point[point];
+                                        int tag = (from << 8) | to;
+                                        MPI_Request req;
+                                        MPI_Irecv(
+                                            point_inputs[point_n_inputs].data(),
+                                            point_inputs[point_n_inputs].size(),
+                                            MPI_BYTE, rank_by_point[dep], tag,
+                                            MPI_COMM_WORLD, &req);
+                                        requests.push_back(req);
+                                    }
+                                    point_n_inputs++;
+                                }
+                            }
+                        }
+
+                        if (point >= last_offset &&
+                            point < last_offset + last_width)
+                        {
+                            auto& point_rev_deps = rev_deps[point_index];
+                            for (auto interval : point_rev_deps)
+                            {
+                                for (long dep = interval.first;
+                                    dep <= interval.second; dep++)
+                                {
+                                    if (dep < offset || dep >= offset + width ||
+                                        (first_point <= dep &&
+                                            dep <= last_point))
+                                    {
+                                        continue;
+                                    }
+                                    int from = tag_bits_by_point[point];
+                                    int to = tag_bits_by_point[dep];
+                                    int tag = (from << 8) | to;
+                                    MPI_Request req;
+                                    MPI_Isend(point_output.data(),
+                                        point_output.size(), MPI_BYTE,
+                                        rank_by_point[dep], tag, MPI_COMM_WORLD,
+                                        &req);
+                                    requests.push_back(req);
+                                }
+                            }
+                        }
+                    }
+
+                    MPI_Waitall(
+                        requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+
+                    long start = std::max(first_point, offset);
+                    long end = std::min(last_point + 1, offset + width);
+                    if (start < end)
+                    {
+                        hpx::experimental::for_loop(
+                            policy, start, end, [&](int point) {
+                                long point_index = point - first_point;
+                                auto& point_input_ptr = input_ptr[point_index];
+                                auto& point_input_bytes =
+                                    input_bytes[point_index];
+                                auto& point_n_inputs = n_inputs[point_index];
+                                auto& point_output = outputs[point_index];
+
+                                graph.execute_point(timestep, point,
+                                    point_output.data(), point_output.size(),
+                                    point_input_ptr.data(),
+                                    point_input_bytes.data(), point_n_inputs,
+                                    scratch_ptr + scratch_bytes * point_index,
+                                    scratch_bytes);
+                            });
+                    }
+                }
+            }
+        }
+
+        double stop_time = MPI_Wtime();
+        elapsed_time = stop_time - start_time;
+    }
+
+    if (rank == 0)
+    {
+        app.report_timing(elapsed_time);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {
+        "hpx.run_hpx_main!=1",
+        "--hpx:ini=hpx.commandline.allow_unknown!=1",
+        "--hpx:ini=hpx.commandline.aliasing!=0",
+    };
+
+    int provided = MPI_THREAD_MULTIPLE;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    if (provided != MPI_THREAD_MULTIPLE)
+    {
+        std::cout << "Provided MPI is not : MPI_THREAD_MULTIPLE " << provided
+                  << std::endl;
+    }
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    auto result = hpx::init(argc, argv, init_args);
+
+    MPI_Finalize();
+
+    return result;
+}

--- a/hpx/hpx_task_bench.cpp
+++ b/hpx/hpx_task_bench.cpp
@@ -78,7 +78,7 @@ int hpx_main(int argc, char* argv[])
     if (chunk_size < 1)
         chunk_size = 1;
 
-    hpx::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::experimental::static_chunk_size cs(chunk_size);
 
     using executor = hpx::execution::experimental::fork_join_executor;
     executor exec(hpx::threads::thread_priority::normal,
@@ -220,7 +220,7 @@ int hpx_main(int argc, char* argv[])
                     auto& deps = dependencies[dset];
                     auto& rev_deps = reverse_dependencies[dset];
 
-                    hpx::for_loop(
+                    hpx::experimental::for_loop(
                         policy, first_point, last_point + 1, [&](int point) {
                             std::vector<MPI_Request> requests;
                             long point_index = point - first_point;
@@ -445,7 +445,7 @@ int hpx_main(int argc, char* argv[])
                     long end = std::min(last_point + 1, offset + width);
                     if (start < end)
                     {
-                        hpx::for_loop(
+                        hpx::experimental::for_loop(
                             policy, start, end, [&](int point) {
                                 long point_index = point - first_point;
                                 auto& point_input_ptr = input_ptr[point_index];

--- a/hpx/hpx_task_bench.cpp
+++ b/hpx/hpx_task_bench.cpp
@@ -78,7 +78,7 @@ int hpx_main(int argc, char* argv[])
     if (chunk_size < 1)
         chunk_size = 1;
 
-    hpx::execution::experimental::static_chunk_size cs(chunk_size);
+    hpx::execution::static_chunk_size cs(chunk_size);
 
     using executor = hpx::execution::experimental::fork_join_executor;
     executor exec(hpx::threads::thread_priority::normal,
@@ -220,7 +220,7 @@ int hpx_main(int argc, char* argv[])
                     auto& deps = dependencies[dset];
                     auto& rev_deps = reverse_dependencies[dset];
 
-                    hpx::experimental::for_loop(
+                    hpx::for_loop(
                         policy, first_point, last_point + 1, [&](int point) {
                             std::vector<MPI_Request> requests;
                             long point_index = point - first_point;
@@ -445,7 +445,7 @@ int hpx_main(int argc, char* argv[])
                     long end = std::min(last_point + 1, offset + width);
                     if (start < end)
                     {
-                        hpx::experimental::for_loop(
+                        hpx::for_loop(
                             policy, start, end, [&](int point) {
                                 long point_index = point - first_point;
                                 auto& point_input_ptr = input_ptr[point_index];

--- a/hpx/hpx_task_bench.cpp
+++ b/hpx/hpx_task_bench.cpp
@@ -30,476 +30,384 @@
 #define MPI_STATUSES_IGNORE 0
 #define MPI_THREAD_MULTIPLE 0
 typedef int MPI_Request;
-inline void MPI_Comm_size(int, int* s)
-{
-    *s = 1;
-}
-inline void MPI_Comm_rank(int, int* r)
-{
-    *r = 0;
-}
+inline void MPI_Comm_size(int, int* s) { *s = 1; }
+inline void MPI_Comm_rank(int, int* r) { *r = 0; }
 inline void MPI_Barrier(int) {}
 inline double MPI_Wtime()
 {
-    static auto start = std::chrono::steady_clock::now();
-    auto now = std::chrono::steady_clock::now();
-    return std::chrono::duration<double>(now - start).count();
+  static auto start = std::chrono::steady_clock::now();
+  auto now = std::chrono::steady_clock::now();
+  return std::chrono::duration<double>(now - start).count();
 }
 inline void MPI_Init_thread(int*, char***, int, int* p)
 {
-    *p = MPI_THREAD_MULTIPLE;
+  *p = MPI_THREAD_MULTIPLE;
 }
 inline void MPI_Finalize() {}
 
 inline void MPI_Irecv(void*, int, int, int, int, int, MPI_Request*)
 {
-    std::abort();
+  std::abort();
 }
 inline void MPI_Isend(void*, int, int, int, int, int, MPI_Request*)
 {
-    std::abort();
+  std::abort();
 }
 inline void MPI_Waitall(int, MPI_Request*, int) {}
 #endif
 
 int hpx_main(int argc, char* argv[])
 {
-    int n_ranks, rank;
-    MPI_Comm_size(MPI_COMM_WORLD, &n_ranks);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  int n_ranks, rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &n_ranks);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    App app(argc, argv);
-    if (rank == 0)
-        app.display();
+  App app(argc, argv);
+  if (rank == 0) app.display();
 
-    int chunk_size =
-        app.graphs[0].max_width / (n_ranks * hpx::get_os_thread_count());
+  int chunk_size =
+      app.graphs[0].max_width / (n_ranks * hpx::get_os_thread_count());
 
-    if (chunk_size < 1)
-        chunk_size = 1;
+  if (chunk_size < 1) chunk_size = 1;
 
-    hpx::execution::experimental::static_chunk_size cs(chunk_size);
+  hpx::execution::experimental::static_chunk_size cs(chunk_size);
 
-    using executor = hpx::execution::experimental::fork_join_executor;
-    executor exec(hpx::threads::thread_priority::normal,
-        hpx::threads::thread_stacksize::small_,
-        chunk_size == 1 ? executor::loop_schedule::static_ :
-                          executor::loop_schedule::dynamic,
-        std::chrono::microseconds(100));
+  using executor = hpx::execution::experimental::fork_join_executor;
+  executor exec(hpx::threads::thread_priority::normal,
+                hpx::threads::thread_stacksize::small_,
+                chunk_size == 1 ? executor::loop_schedule::static_
+                                : executor::loop_schedule::dynamic,
+                std::chrono::microseconds(100));
 
-    auto policy = hpx::execution::par.on(exec).with(cs);
+  auto policy = hpx::execution::par.on(exec).with(cs);
 
-    std::vector<std::vector<char>> scratch;
+  std::vector<std::vector<char>> scratch;
 
-    for (auto graph : app.graphs)
-    {
-        long first_point = rank * graph.max_width / n_ranks;
-        long last_point = (rank + 1) * graph.max_width / n_ranks - 1;
-        long n_points = last_point - first_point + 1;
+  for (auto graph : app.graphs) {
+    long first_point = rank * graph.max_width / n_ranks;
+    long last_point = (rank + 1) * graph.max_width / n_ranks - 1;
+    long n_points = last_point - first_point + 1;
 
-        size_t scratch_bytes = graph.scratch_bytes_per_task;
-        scratch.emplace_back(scratch_bytes * n_points);
-        TaskGraph::prepare_scratch(
-            scratch.back().data(), scratch.back().size());
-    }
+    size_t scratch_bytes = graph.scratch_bytes_per_task;
+    scratch.emplace_back(scratch_bytes * n_points);
+    TaskGraph::prepare_scratch(scratch.back().data(), scratch.back().size());
+  }
 
-    double elapsed_time = 0.0;
+  double elapsed_time = 0.0;
 
-    for (int iter = 0; iter < 2; ++iter)
-    {
-        MPI_Barrier(MPI_COMM_WORLD);
+  for (int iter = 0; iter < 2; ++iter) {
+    MPI_Barrier(MPI_COMM_WORLD);
 
-        double start_time = MPI_Wtime();
+    double start_time = MPI_Wtime();
 
-        for (auto graph : app.graphs)
-        {
-            long first_point = rank * graph.max_width / n_ranks;
-            long last_point = (rank + 1) * graph.max_width / n_ranks - 1;
-            long n_points = last_point - first_point + 1;
+    for (auto graph : app.graphs) {
+      long first_point = rank * graph.max_width / n_ranks;
+      long last_point = (rank + 1) * graph.max_width / n_ranks - 1;
+      long n_points = last_point - first_point + 1;
 
-            size_t scratch_bytes = graph.scratch_bytes_per_task;
-            char* scratch_ptr = scratch[graph.graph_index].data();
+      size_t scratch_bytes = graph.scratch_bytes_per_task;
+      char* scratch_ptr = scratch[graph.graph_index].data();
 
-            std::vector<int> rank_by_point(graph.max_width);
-            std::vector<int> tag_bits_by_point(graph.max_width);
+      std::vector<int> rank_by_point(graph.max_width);
+      std::vector<int> tag_bits_by_point(graph.max_width);
 
-            for (int r = 0; r < n_ranks; ++r)
-            {
-                long r_first_point = r * graph.max_width / n_ranks;
-                long r_last_point = (r + 1) * graph.max_width / n_ranks - 1;
-                for (long p = r_first_point; p <= r_last_point; ++p)
-                {
-                    rank_by_point[p] = r;
-                    tag_bits_by_point[p] = p - r_first_point;
-                    assert((tag_bits_by_point[p] & ~0x7F) == 0);
-                }
-            }
+      for (int r = 0; r < n_ranks; ++r) {
+        long r_first_point = r * graph.max_width / n_ranks;
+        long r_last_point = (r + 1) * graph.max_width / n_ranks - 1;
+        for (long p = r_first_point; p <= r_last_point; ++p) {
+          rank_by_point[p] = r;
+          tag_bits_by_point[p] = p - r_first_point;
+          assert((tag_bits_by_point[p] & ~0x7F) == 0);
+        }
+      }
 
-            long max_deps = 0;
-            for (long dset = 0; dset < graph.max_dependence_sets(); ++dset)
-            {
-                for (long point = first_point; point <= last_point; ++point)
-                {
-                    long deps = 0;
-                    for (auto interval : graph.dependencies(dset, point))
-                    {
-                        deps += interval.second - interval.first + 1;
-                    }
-                    max_deps = std::max(max_deps, deps);
-                }
-            }
+      long max_deps = 0;
+      for (long dset = 0; dset < graph.max_dependence_sets(); ++dset) {
+        for (long point = first_point; point <= last_point; ++point) {
+          long deps = 0;
+          for (auto interval : graph.dependencies(dset, point)) {
+            deps += interval.second - interval.first + 1;
+          }
+          max_deps = std::max(max_deps, deps);
+        }
+      }
 
-            std::vector<std::vector<std::vector<char>>> inputs(n_points);
-            std::vector<std::vector<char const*>> input_ptr(n_points);
-            std::vector<std::vector<size_t>> input_bytes(n_points);
-            std::vector<long> n_inputs(n_points);
-            std::vector<std::vector<char>> outputs(n_points);
-            std::vector<std::vector<char>> outputs_new(n_points);
+      std::vector<std::vector<std::vector<char>>> inputs(n_points);
+      std::vector<std::vector<char const*>> input_ptr(n_points);
+      std::vector<std::vector<size_t>> input_bytes(n_points);
+      std::vector<long> n_inputs(n_points);
+      std::vector<std::vector<char>> outputs(n_points);
+      std::vector<std::vector<char>> outputs_new(n_points);
 
-            for (long point = first_point; point <= last_point; ++point)
-            {
+      for (long point = first_point; point <= last_point; ++point) {
+        long point_index = point - first_point;
+
+        auto& point_inputs = inputs[point_index];
+        auto& point_input_ptr = input_ptr[point_index];
+        auto& point_input_bytes = input_bytes[point_index];
+
+        point_inputs.resize(max_deps);
+        point_input_ptr.resize(max_deps);
+        point_input_bytes.resize(max_deps);
+
+        for (long dep = 0; dep < max_deps; ++dep) {
+          point_inputs[dep].resize(graph.output_bytes_per_task);
+          point_input_ptr[dep] = point_inputs[dep].data();
+          point_input_bytes[dep] = point_inputs[dep].size();
+        }
+
+        auto& point_outputs = outputs[point_index];
+        point_outputs.resize(graph.output_bytes_per_task);
+
+        auto& point_outputs_new = outputs_new[point_index];
+        point_outputs_new.resize(graph.output_bytes_per_task);
+      }
+
+      std::vector<std::vector<std::vector<std::pair<long, long>>>> dependencies(
+          graph.max_dependence_sets());
+      std::vector<std::vector<std::vector<std::pair<long, long>>>>
+          reverse_dependencies(graph.max_dependence_sets());
+      for (long dset = 0; dset < graph.max_dependence_sets(); ++dset) {
+        dependencies[dset].resize(n_points);
+        reverse_dependencies[dset].resize(n_points);
+
+        for (long point = first_point; point <= last_point; ++point) {
+          long point_index = point - first_point;
+
+          dependencies[dset][point_index] = graph.dependencies(dset, point);
+          reverse_dependencies[dset][point_index] =
+              graph.reverse_dependencies(dset, point);
+        }
+      }
+
+      auto is_optimized = [&](DependenceType d) {
+        return d == RANDOM_NEAREST || d == NEAREST || d == STENCIL_1D ||
+               d == STENCIL_1D_PERIODIC || d == FFT || d == NO_COMM ||
+               d == TRIVIAL;
+      };
+
+      if (is_optimized(graph.dependence)) {
+        for (long timestep = 0; timestep < graph.timesteps; ++timestep) {
+          long offset = graph.offset_at_timestep(timestep);
+          long width = graph.width_at_timestep(timestep);
+          long last_offset = graph.offset_at_timestep(timestep - 1);
+          long last_width = graph.width_at_timestep(timestep - 1);
+          long dset = graph.dependence_set_at_timestep(timestep);
+          auto& deps = dependencies[dset];
+          auto& rev_deps = reverse_dependencies[dset];
+
+          hpx::experimental::for_loop(
+              policy, first_point, last_point + 1, [&](int point) {
+                std::vector<MPI_Request> requests;
                 long point_index = point - first_point;
-
-                auto& point_inputs = inputs[point_index];
+                auto& point_n_inputs = n_inputs[point_index];
+                auto& point_output = outputs[point_index];
+                auto& point_output_new = outputs_new[point_index];
                 auto& point_input_ptr = input_ptr[point_index];
                 auto& point_input_bytes = input_bytes[point_index];
 
-                point_inputs.resize(max_deps);
-                point_input_ptr.resize(max_deps);
-                point_input_bytes.resize(max_deps);
-
-                for (long dep = 0; dep < max_deps; ++dep)
-                {
-                    point_inputs[dep].resize(graph.output_bytes_per_task);
-                    point_input_ptr[dep] = point_inputs[dep].data();
-                    point_input_bytes[dep] = point_inputs[dep].size();
-                }
-
-                auto& point_outputs = outputs[point_index];
-                point_outputs.resize(graph.output_bytes_per_task);
-
-                auto& point_outputs_new = outputs_new[point_index];
-                point_outputs_new.resize(graph.output_bytes_per_task);
-            }
-
-            std::vector<std::vector<std::vector<std::pair<long, long>>>>
-                dependencies(graph.max_dependence_sets());
-            std::vector<std::vector<std::vector<std::pair<long, long>>>>
-                reverse_dependencies(graph.max_dependence_sets());
-            for (long dset = 0; dset < graph.max_dependence_sets(); ++dset)
-            {
-                dependencies[dset].resize(n_points);
-                reverse_dependencies[dset].resize(n_points);
-
-                for (long point = first_point; point <= last_point; ++point)
-                {
-                    long point_index = point - first_point;
-
-                    dependencies[dset][point_index] =
-                        graph.dependencies(dset, point);
-                    reverse_dependencies[dset][point_index] =
-                        graph.reverse_dependencies(dset, point);
-                }
-            }
-
-            auto is_optimized = [&](DependenceType d) {
-                return d == RANDOM_NEAREST || d == NEAREST || d == STENCIL_1D ||
-                    d == STENCIL_1D_PERIODIC || d == FFT || d == NO_COMM ||
-                    d == TRIVIAL;
-            };
-
-            if (is_optimized(graph.dependence))
-            {
-                for (long timestep = 0; timestep < graph.timesteps; ++timestep)
-                {
-                    long offset = graph.offset_at_timestep(timestep);
-                    long width = graph.width_at_timestep(timestep);
-                    long last_offset = graph.offset_at_timestep(timestep - 1);
-                    long last_width = graph.width_at_timestep(timestep - 1);
-                    long dset = graph.dependence_set_at_timestep(timestep);
-                    auto& deps = dependencies[dset];
-                    auto& rev_deps = reverse_dependencies[dset];
-
-                    hpx::experimental::for_loop(
-                        policy, first_point, last_point + 1, [&](int point) {
-                            std::vector<MPI_Request> requests;
-                            long point_index = point - first_point;
-                            auto& point_n_inputs = n_inputs[point_index];
-                            auto& point_output = outputs[point_index];
-                            auto& point_output_new = outputs_new[point_index];
-                            auto& point_input_ptr = input_ptr[point_index];
-                            auto& point_input_bytes = input_bytes[point_index];
-
-                            point_n_inputs = 0;
-                            if (point >= offset && point < offset + width)
-                            {
-                                auto& point_inputs = inputs[point_index];
-                                auto& point_deps = deps[point_index];
-                                for (auto interval : point_deps)
-                                {
-                                    for (long dep = interval.first;
-                                        dep <= interval.second; ++dep)
-                                    {
-                                        if (dep < last_offset ||
-                                            dep >= last_offset + last_width)
-                                        {
-                                            continue;
-                                        }
-                                        if (first_point <= dep &&
-                                            dep <= last_point)
-                                        {
-                                            if (timestep % 2 == 0)
-                                            {
-                                                auto& output =
-                                                    outputs[dep - first_point];
-                                                point_inputs[point_n_inputs]
-                                                    .assign(output.begin(),
-                                                        output.end());
-                                            }
-                                            else
-                                            {
-                                                auto& output_new =
-                                                    outputs_new[dep -
-                                                        first_point];
-                                                point_inputs[point_n_inputs]
-                                                    .assign(output_new.begin(),
-                                                        output_new.end());
-                                            }
-                                        }
-                                        else
-                                        {
-                                            int from = tag_bits_by_point[dep];
-                                            int to = tag_bits_by_point[point];
-                                            int tag = (from << 8) | to;
-                                            MPI_Request req;
-                                            MPI_Irecv(
-                                                point_inputs[point_n_inputs]
-                                                    .data(),
-                                                point_inputs[point_n_inputs]
-                                                    .size(),
-                                                MPI_BYTE, rank_by_point[dep],
-                                                tag, MPI_COMM_WORLD, &req);
-                                            requests.push_back(req);
-                                        }
-                                        point_n_inputs++;
-                                    }
-                                }
-                            }
-
-                            if (point >= last_offset &&
-                                point < last_offset + last_width)
-                            {
-                                auto& point_rev_deps = rev_deps[point_index];
-                                for (auto interval : point_rev_deps)
-                                {
-                                    for (long dep = interval.first;
-                                        dep <= interval.second; dep++)
-                                    {
-                                        if (dep < offset ||
-                                            dep >= offset + width ||
-                                            (first_point <= dep &&
-                                                dep <= last_point))
-                                        {
-                                            continue;
-                                        }
-                                        int from = tag_bits_by_point[point];
-                                        int to = tag_bits_by_point[dep];
-                                        int tag = (from << 8) | to;
-                                        MPI_Request req;
-                                        if (timestep % 2 == 0)
-                                        {
-                                            MPI_Isend(point_output.data(),
-                                                point_output.size(), MPI_BYTE,
-                                                rank_by_point[dep], tag,
-                                                MPI_COMM_WORLD, &req);
-                                        }
-                                        else
-                                        {
-                                            MPI_Isend(point_output_new.data(),
-                                                point_output_new.size(),
-                                                MPI_BYTE, rank_by_point[dep],
-                                                tag, MPI_COMM_WORLD, &req);
-                                        }
-                                        requests.push_back(req);
-                                    }
-                                }
-                            }
-
-                            MPI_Waitall(requests.size(), requests.data(),
-                                MPI_STATUSES_IGNORE);
-
-                            if (timestep % 2 == 0)
-                            {
-                                graph.execute_point(timestep, point,
-                                    point_output_new.data(),
-                                    point_output_new.size(),
-                                    point_input_ptr.data(),
-                                    point_input_bytes.data(), point_n_inputs,
-                                    scratch_ptr + scratch_bytes * point_index,
-                                    scratch_bytes);
-                            }
-                            else
-                            {
-                                graph.execute_point(timestep, point,
-                                    point_output.data(), point_output.size(),
-                                    point_input_ptr.data(),
-                                    point_input_bytes.data(), point_n_inputs,
-                                    scratch_ptr + scratch_bytes * point_index,
-                                    scratch_bytes);
-                            }
-                        });
-                }
-            }
-            else
-            {
-                for (long timestep = 0; timestep < graph.timesteps; ++timestep)
-                {
-                    long offset = graph.offset_at_timestep(timestep);
-                    long width = graph.width_at_timestep(timestep);
-                    long last_offset = graph.offset_at_timestep(timestep - 1);
-                    long last_width = graph.width_at_timestep(timestep - 1);
-                    long dset = graph.dependence_set_at_timestep(timestep);
-                    auto& deps = dependencies[dset];
-                    auto& rev_deps = reverse_dependencies[dset];
-
-                    std::vector<MPI_Request> requests;
-                    for (long point = first_point; point <= last_point; ++point)
-                    {
-                        long point_index = point - first_point;
-                        auto& point_n_inputs = n_inputs[point_index];
-                        auto& point_output = outputs[point_index];
-
-                        point_n_inputs = 0;
-                        if (point >= offset && point < offset + width)
-                        {
-                            auto& point_inputs = inputs[point_index];
-                            auto& point_deps = deps[point_index];
-                            for (auto interval : point_deps)
-                            {
-                                for (long dep = interval.first;
-                                    dep <= interval.second; ++dep)
-                                {
-                                    if (dep < last_offset ||
-                                        dep >= last_offset + last_width)
-                                    {
-                                        continue;
-                                    }
-                                    if (first_point <= dep && dep <= last_point)
-                                    {
-                                        auto& output =
-                                            outputs[dep - first_point];
-                                        point_inputs[point_n_inputs].assign(
-                                            output.begin(), output.end());
-                                    }
-                                    else
-                                    {
-                                        int from = tag_bits_by_point[dep];
-                                        int to = tag_bits_by_point[point];
-                                        int tag = (from << 8) | to;
-                                        MPI_Request req;
-                                        MPI_Irecv(
-                                            point_inputs[point_n_inputs].data(),
-                                            point_inputs[point_n_inputs].size(),
-                                            MPI_BYTE, rank_by_point[dep], tag,
-                                            MPI_COMM_WORLD, &req);
-                                        requests.push_back(req);
-                                    }
-                                    point_n_inputs++;
-                                }
-                            }
+                point_n_inputs = 0;
+                if (point >= offset && point < offset + width) {
+                  auto& point_inputs = inputs[point_index];
+                  auto& point_deps = deps[point_index];
+                  for (auto interval : point_deps) {
+                    for (long dep = interval.first; dep <= interval.second;
+                         ++dep) {
+                      if (dep < last_offset ||
+                          dep >= last_offset + last_width) {
+                        continue;
+                      }
+                      if (first_point <= dep && dep <= last_point) {
+                        if (timestep % 2 == 0) {
+                          auto& output = outputs[dep - first_point];
+                          point_inputs[point_n_inputs].assign(output.begin(),
+                                                              output.end());
+                        } else {
+                          auto& output_new = outputs_new[dep - first_point];
+                          point_inputs[point_n_inputs].assign(
+                              output_new.begin(), output_new.end());
                         }
-
-                        if (point >= last_offset &&
-                            point < last_offset + last_width)
-                        {
-                            auto& point_rev_deps = rev_deps[point_index];
-                            for (auto interval : point_rev_deps)
-                            {
-                                for (long dep = interval.first;
-                                    dep <= interval.second; dep++)
-                                {
-                                    if (dep < offset || dep >= offset + width ||
-                                        (first_point <= dep &&
-                                            dep <= last_point))
-                                    {
-                                        continue;
-                                    }
-                                    int from = tag_bits_by_point[point];
-                                    int to = tag_bits_by_point[dep];
-                                    int tag = (from << 8) | to;
-                                    MPI_Request req;
-                                    MPI_Isend(point_output.data(),
-                                        point_output.size(), MPI_BYTE,
-                                        rank_by_point[dep], tag, MPI_COMM_WORLD,
-                                        &req);
-                                    requests.push_back(req);
-                                }
-                            }
-                        }
+                      } else {
+                        int from = tag_bits_by_point[dep];
+                        int to = tag_bits_by_point[point];
+                        int tag = (from << 8) | to;
+                        MPI_Request req;
+                        MPI_Irecv(point_inputs[point_n_inputs].data(),
+                                  point_inputs[point_n_inputs].size(), MPI_BYTE,
+                                  rank_by_point[dep], tag, MPI_COMM_WORLD,
+                                  &req);
+                        requests.push_back(req);
+                      }
+                      point_n_inputs++;
                     }
-
-                    MPI_Waitall(
-                        requests.size(), requests.data(), MPI_STATUSES_IGNORE);
-
-                    long start = std::max(first_point, offset);
-                    long end = std::min(last_point + 1, offset + width);
-                    if (start < end)
-                    {
-                        hpx::experimental::for_loop(
-                            policy, start, end, [&](int point) {
-                                long point_index = point - first_point;
-                                auto& point_input_ptr = input_ptr[point_index];
-                                auto& point_input_bytes =
-                                    input_bytes[point_index];
-                                auto& point_n_inputs = n_inputs[point_index];
-                                auto& point_output = outputs[point_index];
-
-                                graph.execute_point(timestep, point,
-                                    point_output.data(), point_output.size(),
-                                    point_input_ptr.data(),
-                                    point_input_bytes.data(), point_n_inputs,
-                                    scratch_ptr + scratch_bytes * point_index,
-                                    scratch_bytes);
-                            });
-                    }
+                  }
                 }
-            }
+
+                if (point >= last_offset && point < last_offset + last_width) {
+                  auto& point_rev_deps = rev_deps[point_index];
+                  for (auto interval : point_rev_deps) {
+                    for (long dep = interval.first; dep <= interval.second;
+                         dep++) {
+                      if (dep < offset || dep >= offset + width ||
+                          (first_point <= dep && dep <= last_point)) {
+                        continue;
+                      }
+                      int from = tag_bits_by_point[point];
+                      int to = tag_bits_by_point[dep];
+                      int tag = (from << 8) | to;
+                      MPI_Request req;
+                      if (timestep % 2 == 0) {
+                        MPI_Isend(point_output.data(), point_output.size(),
+                                  MPI_BYTE, rank_by_point[dep], tag,
+                                  MPI_COMM_WORLD, &req);
+                      } else {
+                        MPI_Isend(point_output_new.data(),
+                                  point_output_new.size(), MPI_BYTE,
+                                  rank_by_point[dep], tag, MPI_COMM_WORLD,
+                                  &req);
+                      }
+                      requests.push_back(req);
+                    }
+                  }
+                }
+
+                MPI_Waitall(requests.size(), requests.data(),
+                            MPI_STATUSES_IGNORE);
+
+                if (timestep % 2 == 0) {
+                  graph.execute_point(
+                      timestep, point, point_output_new.data(),
+                      point_output_new.size(), point_input_ptr.data(),
+                      point_input_bytes.data(), point_n_inputs,
+                      scratch_ptr + scratch_bytes * point_index, scratch_bytes);
+                } else {
+                  graph.execute_point(
+                      timestep, point, point_output.data(), point_output.size(),
+                      point_input_ptr.data(), point_input_bytes.data(),
+                      point_n_inputs, scratch_ptr + scratch_bytes * point_index,
+                      scratch_bytes);
+                }
+              });
         }
+      } else {
+        for (long timestep = 0; timestep < graph.timesteps; ++timestep) {
+          long offset = graph.offset_at_timestep(timestep);
+          long width = graph.width_at_timestep(timestep);
+          long last_offset = graph.offset_at_timestep(timestep - 1);
+          long last_width = graph.width_at_timestep(timestep - 1);
+          long dset = graph.dependence_set_at_timestep(timestep);
+          auto& deps = dependencies[dset];
+          auto& rev_deps = reverse_dependencies[dset];
 
-        double stop_time = MPI_Wtime();
-        elapsed_time = stop_time - start_time;
+          std::vector<MPI_Request> requests;
+          for (long point = first_point; point <= last_point; ++point) {
+            long point_index = point - first_point;
+            auto& point_n_inputs = n_inputs[point_index];
+            auto& point_output = outputs[point_index];
+
+            point_n_inputs = 0;
+            if (point >= offset && point < offset + width) {
+              auto& point_inputs = inputs[point_index];
+              auto& point_deps = deps[point_index];
+              for (auto interval : point_deps) {
+                for (long dep = interval.first; dep <= interval.second; ++dep) {
+                  if (dep < last_offset || dep >= last_offset + last_width) {
+                    continue;
+                  }
+                  if (first_point <= dep && dep <= last_point) {
+                    auto& output = outputs[dep - first_point];
+                    point_inputs[point_n_inputs].assign(output.begin(),
+                                                        output.end());
+                  } else {
+                    int from = tag_bits_by_point[dep];
+                    int to = tag_bits_by_point[point];
+                    int tag = (from << 8) | to;
+                    MPI_Request req;
+                    MPI_Irecv(point_inputs[point_n_inputs].data(),
+                              point_inputs[point_n_inputs].size(), MPI_BYTE,
+                              rank_by_point[dep], tag, MPI_COMM_WORLD, &req);
+                    requests.push_back(req);
+                  }
+                  point_n_inputs++;
+                }
+              }
+            }
+
+            if (point >= last_offset && point < last_offset + last_width) {
+              auto& point_rev_deps = rev_deps[point_index];
+              for (auto interval : point_rev_deps) {
+                for (long dep = interval.first; dep <= interval.second; dep++) {
+                  if (dep < offset || dep >= offset + width ||
+                      (first_point <= dep && dep <= last_point)) {
+                    continue;
+                  }
+                  int from = tag_bits_by_point[point];
+                  int to = tag_bits_by_point[dep];
+                  int tag = (from << 8) | to;
+                  MPI_Request req;
+                  MPI_Isend(point_output.data(), point_output.size(), MPI_BYTE,
+                            rank_by_point[dep], tag, MPI_COMM_WORLD, &req);
+                  requests.push_back(req);
+                }
+              }
+            }
+          }
+
+          MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+
+          long start = std::max(first_point, offset);
+          long end = std::min(last_point + 1, offset + width);
+          if (start < end) {
+            hpx::experimental::for_loop(policy, start, end, [&](int point) {
+              long point_index = point - first_point;
+              auto& point_input_ptr = input_ptr[point_index];
+              auto& point_input_bytes = input_bytes[point_index];
+              auto& point_n_inputs = n_inputs[point_index];
+              auto& point_output = outputs[point_index];
+
+              graph.execute_point(timestep, point, point_output.data(),
+                                  point_output.size(), point_input_ptr.data(),
+                                  point_input_bytes.data(), point_n_inputs,
+                                  scratch_ptr + scratch_bytes * point_index,
+                                  scratch_bytes);
+            });
+          }
+        }
+      }
     }
 
-    if (rank == 0)
-    {
-        app.report_timing(elapsed_time);
-    }
+    double stop_time = MPI_Wtime();
+    elapsed_time = stop_time - start_time;
+  }
 
-    return hpx::finalize();
+  if (rank == 0) {
+    app.report_timing(elapsed_time);
+  }
+
+  return hpx::finalize();
 }
 
 int main(int argc, char* argv[])
 {
-    std::vector<std::string> const cfg = {
-        "hpx.run_hpx_main!=1",
-        "--hpx:ini=hpx.commandline.allow_unknown!=1",
-        "--hpx:ini=hpx.commandline.aliasing!=0",
-    };
+  std::vector<std::string> const cfg = {
+      "hpx.run_hpx_main!=1",
+      "--hpx:ini=hpx.commandline.allow_unknown!=1",
+      "--hpx:ini=hpx.commandline.aliasing!=0",
+  };
 
-    int provided = MPI_THREAD_MULTIPLE;
-    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
-    if (provided != MPI_THREAD_MULTIPLE)
-    {
-        std::cout << "Provided MPI is not : MPI_THREAD_MULTIPLE " << provided
-                  << std::endl;
-    }
+  int provided = MPI_THREAD_MULTIPLE;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+  if (provided != MPI_THREAD_MULTIPLE) {
+    std::cout << "Provided MPI is not : MPI_THREAD_MULTIPLE " << provided
+              << std::endl;
+  }
 
-    hpx::init_params init_args;
-    init_args.cfg = cfg;
+  hpx::init_params init_args;
+  init_args.cfg = cfg;
 
-    auto result = hpx::init(argc, argv, init_args);
+  auto result = hpx::init(argc, argv, init_args);
 
-    MPI_Finalize();
+  MPI_Finalize();
 
-    return result;
+  return result;
 }

--- a/test_all.sh
+++ b/test_all.sh
@@ -195,17 +195,15 @@ fi
         done
     done
 
-    # FIXME: hpx_distributed is known to freeze nondeterministically due to a
-    # synchronization bug in the MPI+HPX implementation (see issue #94).
-    # Skip these tests until the bug is resolved.
-    # for t in "${extended_types[@]}"; do
-    #     for k in "${kernels[@]}"; do
-    #         mpirun -np 1 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
-    #         mpirun -np 2 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
-    #         mpirun -np 4 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
-    #         mpirun -np 4 ./hpx/bin/hpx_distributed -steps $steps -type $t $k  -and -steps $steps -type $t $k
-    #     done
-    # done
+    # Test hpx_distributed (default parallel executor + MPI)
+    for t in "${extended_types[@]}"; do
+        for k in "${kernels[@]}"; do
+            mpirun -np 1 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
+            mpirun -np 2 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
+            mpirun -np 4 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
+            mpirun -np 4 ./hpx/bin/hpx_distributed -steps $steps -type $t $k -and -steps $steps -type $t $k
+        done
+    done
 fi)
 
 if [[ $USE_CHAPEL -eq 1 ]]; then

--- a/test_all.sh
+++ b/test_all.sh
@@ -187,11 +187,11 @@ fi
 (if [[ $USE_HPX -eq 1 ]]; then
     source "$HPX_DIR"/env.sh
 
-    # Test hpx_task_bench (fork-join executor, no MPI required)
+    # Test hpx_fork_join (fork-join executor, no MPI required)
     for t in "${extended_types[@]}"; do
         for k in "${kernels[@]}"; do
-            ./hpx/bin/hpx_task_bench -steps $steps -type $t $k
-            ./hpx/bin/hpx_task_bench -steps $steps -type $t $k -and -steps $steps -type $t $k
+            ./hpx/bin/hpx_fork_join -steps $steps -type $t $k
+            ./hpx/bin/hpx_fork_join -steps $steps -type $t $k -and -steps $steps -type $t $k
         done
     done
 

--- a/test_all.sh
+++ b/test_all.sh
@@ -195,15 +195,17 @@ fi
         done
     done
 
-    # Test hpx_distributed (requires MPI)
-    for t in "${extended_types[@]}"; do
-        for k in "${kernels[@]}"; do
-            mpirun -np 1 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
-            mpirun -np 2 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
-            mpirun -np 4 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
-            mpirun -np 4 ./hpx/bin/hpx_distributed -steps $steps -type $t $k  -and -steps $steps -type $t $k
-        done
-    done
+    # FIXME: hpx_distributed is known to freeze nondeterministically due to a
+    # synchronization bug in the MPI+HPX implementation (see issue #94).
+    # Skip these tests until the bug is resolved.
+    # for t in "${extended_types[@]}"; do
+    #     for k in "${kernels[@]}"; do
+    #         mpirun -np 1 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
+    #         mpirun -np 2 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
+    #         mpirun -np 4 ./hpx/bin/hpx_distributed -steps $steps -type $t $k
+    #         mpirun -np 4 ./hpx/bin/hpx_distributed -steps $steps -type $t $k  -and -steps $steps -type $t $k
+    #     done
+    # done
 fi)
 
 if [[ $USE_CHAPEL -eq 1 ]]; then

--- a/test_all.sh
+++ b/test_all.sh
@@ -187,6 +187,15 @@ fi
 (if [[ $USE_HPX -eq 1 ]]; then
     source "$HPX_DIR"/env.sh
 
+    # Test hpx_task_bench (fork-join executor, no MPI required)
+    for t in "${extended_types[@]}"; do
+        for k in "${kernels[@]}"; do
+            ./hpx/bin/hpx_task_bench -steps $steps -type $t $k
+            ./hpx/bin/hpx_task_bench -steps $steps -type $t $k -and -steps $steps -type $t $k
+        done
+    done
+
+    # Test hpx_distributed (requires MPI)
     for t in "${extended_types[@]}"; do
         for k in "${kernels[@]}"; do
             mpirun -np 1 ./hpx/bin/hpx_distributed -steps $steps -type $t $k


### PR DESCRIPTION
This PR adds a new HPX implementation ([hpx_task_bench.cpp](cci:7://file:///Users/pratykshgupta/Desktop/hpx/examples/task_bench/hpx_task_bench.cpp:0:0-0:0)) that uses `hpx::execution::experimental::fork_join_executor` for efficient intra-node task graph execution, complementing the existing distributed implementation.
