### PR TITLE
Fix Regent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           - system: MPI_OPENMP
           - system: LEGION
           # - system: PYGION
-          # - system: REGENT
+          - system: REGENT
           - system: REALM
           # - system: STARPU
           #   hwloc: 1

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.swp
 *.a
 *.o
-*.so
+*.so*
 *.dSYM
 *.pyc
 __pycache__

--- a/build_all.sh
+++ b/build_all.sh
@@ -127,7 +127,6 @@ if [[ $USE_REGENT -eq 1 ]]; then
         if [[ -z $CXX ]]; then
             export CXX=c++
         fi
-        unset LG_RT_DIR
         if [[ -z $GITHUB_ACTIONS ]]; then
             ./scripts/setup_env.py -j$THREADS
         else

--- a/build_all.sh
+++ b/build_all.sh
@@ -134,12 +134,7 @@ if [[ $USE_REGENT -eq 1 ]]; then
         if [[ -n $CRAYPE_VERSION ]]; then
             export CC=gcc CXX=g++
         fi
-        SHARD_SIZE=30 make -C regent -j$THREADS &
-        sleep 1
-        SHARD_SIZE=15 make -C regent -j$THREADS &
-        sleep 1
-        SHARD_SIZE=14 make -C regent -j$THREADS &
-        wait
+        make -C regent -j$THREADS
     )
 fi
 )

--- a/build_all.sh
+++ b/build_all.sh
@@ -127,11 +127,7 @@ if [[ $USE_REGENT -eq 1 ]]; then
         if [[ -z $CXX ]]; then
             export CXX=c++
         fi
-        if [[ -z $GITHUB_ACTIONS ]]; then
-            ./scripts/setup_env.py -j$THREADS
-        else
-            ./install.py
-        fi
+        ./scripts/setup_env.py -j$THREADS
     )
     popd
     (

--- a/ci.sh
+++ b/ci.sh
@@ -12,7 +12,7 @@ fi
 if [[ "$(uname)" = "Linux" ]]; then
   sudo apt-get update -qq
   sudo apt-get install -qq mpich libmpich-dev libpcre3-dev binutils-dev
-  if [[ $USE_CHAPEL -eq 1 || $USE_REGENT -eq 1 ]]; then
+  if [[ $USE_CHAPEL -eq 1 ]]; then
     sudo apt-get install -qq clang-18 libclang-18-dev libclang-cpp18-dev llvm-18-dev libedit-dev libncurses5-dev zlib1g-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-18:/usr/share/llvm-18
   fi

--- a/regent/.gitignore
+++ b/regent/.gitignore
@@ -1,1 +1,1 @@
-/main.shard*
+/task_bench

--- a/regent/Makefile
+++ b/regent/Makefile
@@ -1,9 +1,8 @@
 LEGION_DIR ?= ../deps/legion
-SHARD_SIZE ?= 20
-OUTFILE := main.shard$(SHARD_SIZE)
+OUTFILE := task_bench
 
 $(OUTFILE): main.rg
-	SAVEOBJ=1 STANDALONE=1 OBJNAME=$(OUTFILE) INCLUDE_PATH=../core $(LEGION_DIR)/language/regent.py main.rg -fflow-spmd 1 -fflow-spmd-shardsize $(SHARD_SIZE) -fskip-empty-tasks 0
+	SAVEOBJ=1 STANDALONE=1 OBJNAME=$(OUTFILE) INCLUDE_PATH=../core $(LEGION_DIR)/language/regent.py main.rg
 
 .PHONY: clean
 clean:

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -685,4 +685,10 @@ end
 local root_dir = arg[0]:match(".*/") or "./"
 local core_dir = root_dir .. "../core/"
 regentlib.linklibrary(core_dir .. "libcore.so")
-launcher.launch(main, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-lmapper"})
+if os.getenv('SAVEOBJ') == '1' and os.getenv('STANDALONE') == '1' then
+  -- Hack: work around incomplete launcher support in 26.03.0
+  local out_dir = (os.getenv('OBJNAME') and os.getenv('OBJNAME'):match('.*/')) or root_dir
+  os.execute('cp --no-dereference ' .. os.getenv('LEGION_INSTALL_PREFIX') .. '/lib/liblegion.so* ' .. out_dir)
+  os.execute('cp --no-dereference ' .. os.getenv('LEGION_INSTALL_PREFIX') .. '/lib/librealm.so* ' .. out_dir)
+end
+launcher.launch(main, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN/../core", "-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-lmapper"})

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -682,5 +682,6 @@ task main()
   [dispatch_work_task(n_graphs, n_dsets, max_inputs)]
 end
 
-regentlib.linklibrary("../core/libcore.so")
+local core_dir = root_dir .. "../core/"
+regentlib.linklibrary(core_dir .. "libcore.so")
 launcher.launch(main, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-L" .. out_dir, "-lmapper"})

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -682,6 +682,7 @@ task main()
   [dispatch_work_task(n_graphs, n_dsets, max_inputs)]
 end
 
+local root_dir = arg[0]:match(".*/") or "./"
 local core_dir = root_dir .. "../core/"
 regentlib.linklibrary(core_dir .. "libcore.so")
 launcher.launch(main, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-L" .. out_dir, "-lmapper"})

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -685,4 +685,4 @@ end
 local root_dir = arg[0]:match(".*/") or "./"
 local core_dir = root_dir .. "../core/"
 regentlib.linklibrary(core_dir .. "libcore.so")
-launcher.launch(main, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-L" .. out_dir, "-lmapper"})
+launcher.launch(main, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-lmapper"})

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -14,53 +14,13 @@
 
 import "regent"
 
+local launcher = require("std/launcher")
+
 local c = regentlib.c
 local core = terralib.includec("core_c.h")
 
-do
-  local root_dir = arg[0]:match(".*/") or "./"
-
-  local include_path = ""
-  local include_dirs = terralib.newlist()
-  include_dirs:insert("-I")
-  include_dirs:insert(root_dir)
-  for path in string.gmatch(os.getenv("INCLUDE_PATH"), "[^;]+") do
-    include_path = include_path .. " -I " .. path
-    include_dirs:insert("-I")
-    include_dirs:insert(path)
-  end
-
-  local mapper_cc = root_dir .. "mapper.cc"
-  if os.getenv('OBJNAME') then
-    local out_dir = os.getenv('OBJNAME'):match('.*/') or './'
-    mapper_so = out_dir .. "libmapper.so"
-  elseif os.getenv('SAVEOBJ') == '1' then
-    mapper_so = root_dir .. "libmapper.so"
-  else
-    mapper_so = os.tmpname() .. ".so" -- root_dir .. "mapper.so"
-  end
-  local cxx = os.getenv('CXX') or 'c++'
-  local max_dim = os.getenv('MAX_DIM') or '3'
-
-  local cxx_flags = os.getenv('CC_FLAGS') or ''
-  cxx_flags = cxx_flags .. " -O2 -Wall -Werror -DLEGION_MAX_DIM=" .. max_dim .. " -DREALM_MAX_DIM=" .. max_dim
-  if os.execute('test "$(uname)" = Darwin') == 0 then
-    cxx_flags =
-      (cxx_flags ..
-         " -dynamiclib -single_module -undefined dynamic_lookup -fPIC")
-  else
-    cxx_flags = cxx_flags .. " -shared -fPIC"
-  end
-
-  local cmd = (cxx .. " " .. cxx_flags .. include_path .. " " ..
-                 mapper_cc .. " -o " .. mapper_so)
-  if os.execute(cmd) ~= 0 then
-    print("Error: failed to compile " .. mapper_cc)
-    assert(false)
-  end
-  terralib.linklibrary(mapper_so)
-  cmapper = terralib.includec("mapper.h", include_dirs)
-end
+-- Compile and link mapper.cc
+local cmapper = launcher.build_library("mapper")
 
 local MAX_GRAPHS = 1
 local MAX_DSETS = 3
@@ -722,20 +682,5 @@ task main()
   [dispatch_work_task(n_graphs, n_dsets, max_inputs)]
 end
 
-if os.getenv('SAVEOBJ') == '1' then
-  local root_dir = arg[0]:match(".*/") or "./"
-  local core_dir = root_dir .. "../core/"
-  local out_dir = (os.getenv('OBJNAME') and os.getenv('OBJNAME'):match('.*/')) or root_dir
-  local link_flags = terralib.newlist({"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-L" .. out_dir, "-lmapper"})
-
-  if os.getenv('STANDALONE') == '1' then
-    os.execute('cp ' .. core_dir .. 'libcore.so ' .. out_dir)
-    os.execute('cp ' .. os.getenv('LG_RT_DIR') .. '/../bindings/regent/libregent.so ' .. out_dir)
-  end
-
-  local exe = os.getenv('OBJNAME') or "main"
-  regentlib.saveobj(main, exe, "executable", cmapper.register_mappers, link_flags)
-else
-  terralib.linklibrary("../core/libcore.so")
-  regentlib.start(main, cmapper.register_mappers)
-end
+regentlib.linklibrary("../core/libcore.so")
+launcher.launch(toplevel, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-L" .. out_dir, "-lmapper"})

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -476,17 +476,15 @@ local work_task = terralib.memoize(function(n_graphs, n_dsets, max_inputs)
         regentlib.assert(period % core.task_graph_timestep_period(graph) == 0, "precomputed period is not divisible by task graph period")
         var [max_timesteps] = graph.timesteps
         var [max_width] = graph.max_width
-        __demand(__spmd)
-        do
-          for point = 0, max_width do
-            init_scratch([pscratch[graph_idx]][point])
-          end
 
-          for [trial] = 0, 3 do
-            __demand(__trace)
-            for [timestep] = 0, max_timesteps + period - 1, period do
-              [body_actions]
-            end
+        for point = 0, max_width do
+          init_scratch([pscratch[graph_idx]][point])
+        end
+
+        for [trial] = 0, 3 do
+          __demand(__trace)
+          for [timestep] = 0, max_timesteps + period - 1, period do
+            [body_actions]
           end
         end
       end)
@@ -608,7 +606,7 @@ local work_task = terralib.memoize(function(n_graphs, n_dsets, max_inputs)
 
     regentlib.assert(max_timesteps % 2 == 0, "must run even number of timesteps")
 
-    __demand(__spmd, __trace)
+    __demand(__trace)
     for timestep = 0, max_timesteps, 2 do
       for point = 0, max_width do
         f1(primary[point], secondary[point], pscratch[point], ptime[point],

--- a/regent/main.rg
+++ b/regent/main.rg
@@ -683,4 +683,4 @@ task main()
 end
 
 regentlib.linklibrary("../core/libcore.so")
-launcher.launch(toplevel, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-L" .. out_dir, "-lmapper"})
+launcher.launch(main, "task_bench", cmapper.register_mappers, {"-Wl,-rpath,$ORIGIN", "-L" .. core_dir, "-lcore", "-L" .. out_dir, "-lmapper"})

--- a/regent/mapper.cc
+++ b/regent/mapper.cc
@@ -17,21 +17,16 @@
 
 #include "mappers/default_mapper.h"
 
-#define SPMD_SHARD_USE_IO_PROC 1
-
 using namespace Legion;
 using namespace Legion::Mapping;
 
-static LegionRuntime::Logger::Category log_stencil("stencil");
+static Logger::Category log_task_bench("task_bench");
 
 class TaskBenchMapper : public DefaultMapper
 {
 public:
   TaskBenchMapper(MapperRuntime *rt, Machine machine, Processor local,
                 const char *mapper_name);
-  virtual void default_policy_rank_processor_kinds(
-                                    MapperContext ctx, const Task &task,
-                                    std::vector<Processor::Kind> &ranking);
 };
 
 TaskBenchMapper::TaskBenchMapper(MapperRuntime *rt, Machine machine, Processor local,
@@ -40,32 +35,7 @@ TaskBenchMapper::TaskBenchMapper(MapperRuntime *rt, Machine machine, Processor l
 {
 }
 
-void TaskBenchMapper::default_policy_rank_processor_kinds(MapperContext ctx,
-                        const Task &task, std::vector<Processor::Kind> &ranking)
-{
-#if SPMD_SHARD_USE_IO_PROC
-  const char* task_name = task.get_task_name();
-  const char* prefix = "shard_";
-  if (strncmp(task_name, prefix, strlen(prefix)) == 0) {
-    // Put shard tasks on IO processors.
-    ranking.resize(4);
-    ranking[0] = Processor::TOC_PROC;
-    ranking[1] = Processor::PROC_SET;
-    ranking[2] = Processor::IO_PROC;
-    ranking[3] = Processor::LOC_PROC;
-  } else {
-#endif
-    ranking.resize(4);
-    ranking[0] = Processor::TOC_PROC;
-    ranking[1] = Processor::PROC_SET;
-    ranking[2] = Processor::LOC_PROC;
-    ranking[3] = Processor::IO_PROC;
-#if SPMD_SHARD_USE_IO_PROC
-  }
-#endif
-}
-
-static void create_mappers(Machine machine, HighLevelRuntime *runtime, const std::set<Processor> &local_procs)
+static void create_mappers(Machine machine, Runtime *runtime, const std::set<Processor> &local_procs)
 {
   for (std::set<Processor>::const_iterator it = local_procs.begin();
         it != local_procs.end(); it++)
@@ -78,5 +48,5 @@ static void create_mappers(Machine machine, HighLevelRuntime *runtime, const std
 
 void register_mappers()
 {
-  HighLevelRuntime::add_registration_callback(create_mappers);
+  Runtime::add_registration_callback(create_mappers);
 }

--- a/regent/mapper.cc
+++ b/regent/mapper.cc
@@ -20,7 +20,7 @@
 using namespace Legion;
 using namespace Legion::Mapping;
 
-static Logger::Category log_task_bench("task_bench");
+static Logger log_task_bench("task_bench");
 
 class TaskBenchMapper : public DefaultMapper
 {

--- a/regent/mapper.cc
+++ b/regent/mapper.cc
@@ -20,19 +20,318 @@
 using namespace Legion;
 using namespace Legion::Mapping;
 
-static Logger log_task_bench("task_bench");
+enum ShardingFunctorIDs {
+  SID_LINEAR = 1,
+};
+
+static Logger log_taskbench("taskbench");
+
+class LinearShardingFunctor : public ShardingFunctor {
+public:
+  LinearShardingFunctor();
+  LinearShardingFunctor(const LinearShardingFunctor &rhs);
+  virtual ~LinearShardingFunctor(void);
+public:
+  LinearShardingFunctor& operator=(const LinearShardingFunctor &rhs);
+public:
+  template<int DIM>
+  size_t linearize_point(const Realm::IndexSpace<DIM,coord_t> &is,
+                         const Realm::Point<DIM,coord_t> &point) const;
+public:
+  virtual ShardID shard(const DomainPoint &point,
+                        const Domain &full_space,
+                        const size_t total_shards);
+};
+
+//--------------------------------------------------------------------------
+LinearShardingFunctor::LinearShardingFunctor()
+  : ShardingFunctor()
+//--------------------------------------------------------------------------
+{
+}
+
+//--------------------------------------------------------------------------
+LinearShardingFunctor::LinearShardingFunctor(
+                                           const LinearShardingFunctor &rhs)
+  : ShardingFunctor()
+//--------------------------------------------------------------------------
+{
+  // should never be called
+  assert(false);
+}
+
+//--------------------------------------------------------------------------
+LinearShardingFunctor::~LinearShardingFunctor(void)
+//--------------------------------------------------------------------------
+{
+}
+
+//--------------------------------------------------------------------------
+LinearShardingFunctor& LinearShardingFunctor::operator=(
+                                           const LinearShardingFunctor &rhs)
+//--------------------------------------------------------------------------
+{
+  // should never be called
+  assert(false);
+  return *this;
+}
+
+//--------------------------------------------------------------------------
+template<int DIM>
+size_t LinearShardingFunctor::linearize_point(
+                               const Realm::IndexSpace<DIM,coord_t> &is,
+                               const Realm::Point<DIM,coord_t> &point) const
+//--------------------------------------------------------------------------
+{
+  Realm::AffineLinearizedIndexSpace<DIM,coord_t> linearizer(is);
+  return linearizer.linearize(point);
+}
+
+//--------------------------------------------------------------------------
+ShardID LinearShardingFunctor::shard(const DomainPoint &point,
+                                     const Domain &full_space,
+                                     const size_t total_shards)
+//--------------------------------------------------------------------------
+{
+#ifdef DEBUG_LEGION
+  assert(point.get_dim() == full_space.get_dim());
+#endif
+  size_t domain_size = full_space.get_volume();
+  switch (point.get_dim())
+  {
+    case 1:
+      {
+        const DomainT<1,coord_t> is = full_space;
+        const Point<1,coord_t> p1 = point;
+        return linearize_point<1>(is, p1)  * total_shards / domain_size;
+      }
+    case 2:
+      {
+        const DomainT<2,coord_t> is = full_space;
+        const Point<2,coord_t> p2 = point;
+        return linearize_point<2>(is, p2)  * total_shards / domain_size;
+      }
+    case 3:
+      {
+        const DomainT<3,coord_t> is = full_space;
+        const Point<3,coord_t> p3 = point;
+        return linearize_point<3>(is, p3)  * total_shards / domain_size;
+      }
+    default:
+      assert(false);
+  }
+  return 0;
+}
 
 class TaskBenchMapper : public DefaultMapper
 {
 public:
   TaskBenchMapper(MapperRuntime *rt, Machine machine, Processor local,
-                const char *mapper_name);
+                  const char *mapper_name);
+  virtual void select_sharding_functor(
+                                 const MapperContext                ctx,
+                                 const Task&                        task,
+                                 const SelectShardingFunctorInput&  input,
+                                       SelectShardingFunctorOutput& output);
+  virtual void select_sharding_functor(
+                                 const MapperContext                ctx,
+                                 const Copy&                        copy,
+                                 const SelectShardingFunctorInput&  input,
+                                       SelectShardingFunctorOutput& output);
+  virtual void select_sharding_functor(
+                                 const MapperContext                ctx,
+                                 const Fill&                        fill,
+                                 const SelectShardingFunctorInput&  input,
+                                       SelectShardingFunctorOutput& output);
+  virtual void default_policy_select_target_processors(MapperContext ctx,
+                                                       const Task &task,
+                                                       std::vector<Processor> &target_procs);
+  virtual void slice_task(const MapperContext      ctx,
+                          const Task&              task,
+                          const SliceTaskInput&    input,
+                                SliceTaskOutput&   output);
+  void task_bench_slice_task(const Task &task,
+                             const std::vector<Processor> &local_procs,
+                             const std::vector<Processor> &remote_procs,
+                             const SliceTaskInput &input,
+                                   SliceTaskOutput &output,
+            std::map<Domain,std::vector<TaskSlice> > &cached_slices) const;
 };
 
 TaskBenchMapper::TaskBenchMapper(MapperRuntime *rt, Machine machine, Processor local,
                                  const char *mapper_name)
   : DefaultMapper(rt, machine, local, mapper_name)
 {
+}
+
+void TaskBenchMapper::select_sharding_functor(
+                                 const MapperContext                ctx,
+                                 const Task&                        task,
+                                 const SelectShardingFunctorInput&  input,
+                                       SelectShardingFunctorOutput& output)
+{
+  output.chosen_functor = SID_LINEAR;
+}
+
+void TaskBenchMapper::select_sharding_functor(
+                                 const MapperContext                ctx,
+                                 const Copy&                        copy,
+                                 const SelectShardingFunctorInput&  input,
+                                       SelectShardingFunctorOutput& output)
+{
+  output.chosen_functor = SID_LINEAR;
+}
+
+void TaskBenchMapper::select_sharding_functor(
+                                 const MapperContext                ctx,
+                                 const Fill&                        fill,
+                                 const SelectShardingFunctorInput&  input,
+                                       SelectShardingFunctorOutput& output)
+{
+  output.chosen_functor = SID_LINEAR;
+}
+
+void TaskBenchMapper::default_policy_select_target_processors(MapperContext ctx,
+                                                              const Task &task,
+                                                              std::vector<Processor> &target_procs)
+{
+  target_procs.push_back(task.target_proc);
+}
+
+//--------------------------------------------------------------------------
+void TaskBenchMapper::slice_task(const MapperContext      ctx,
+                                 const Task&              task,
+                                 const SliceTaskInput&    input,
+                                       SliceTaskOutput&   output)
+//--------------------------------------------------------------------------
+{
+  std::vector<VariantID> variants;
+  runtime->find_valid_variants(ctx, task.task_id, variants);
+  /* find if we have a procset variant for task */
+  for(unsigned i = 0; i < variants.size(); i++)
+  {
+    const ExecutionConstraintSet exset =
+       runtime->find_execution_constraints(ctx, task.task_id, variants[i]);
+    if(exset.processor_constraint.can_use(Processor::PROC_SET)) {
+
+       // Before we do anything else, see if it is in the cache
+       std::map<Domain,std::vector<TaskSlice> >::const_iterator finder =
+         procset_slices_cache.find(input.domain);
+       if (finder != procset_slices_cache.end()) {
+               output.slices = finder->second;
+               return;
+       }
+
+      output.slices.resize(input.domain.get_volume());
+      unsigned idx = 0;
+      Rect<1> rect = input.domain;
+      for (PointInRectIterator<1> pir(rect); pir(); pir++, idx++)
+      {
+        Rect<1> slice(*pir, *pir);
+        output.slices[idx] = TaskSlice(slice,
+          remote_procsets[idx % remote_cpus.size()],
+          false/*recurse*/, false/*stealable*/);
+      }
+
+      // Save the result in the cache
+      procset_slices_cache[input.domain] = output.slices;
+      return;
+    }
+  }
+
+  // Whatever kind of processor we are is the one this task should
+  // be scheduled on as determined by select initial task
+  Processor::Kind target_kind =
+    task.must_epoch_task ? local_proc.kind() : task.target_proc.kind();
+  switch (target_kind)
+  {
+    case Processor::LOC_PROC:
+      {
+        task_bench_slice_task(task, local_cpus, remote_cpus,
+                           input, output, cpu_slices_cache);
+        break;
+      }
+    case Processor::TOC_PROC:
+      {
+        task_bench_slice_task(task, local_gpus, remote_gpus,
+                           input, output, gpu_slices_cache);
+        break;
+      }
+    case Processor::IO_PROC:
+      {
+        task_bench_slice_task(task, local_ios, remote_ios,
+                           input, output, io_slices_cache);
+        break;
+      }
+    case Processor::PY_PROC:
+      {
+        task_bench_slice_task(task, local_pys, remote_pys,
+                           input, output, py_slices_cache);
+        break;
+      }
+    case Processor::PROC_SET:
+      {
+        task_bench_slice_task(task, local_procsets, remote_procsets,
+                           input, output, procset_slices_cache);
+        break;
+      }
+    case Processor::OMP_PROC:
+      {
+        task_bench_slice_task(task, local_omps, remote_omps,
+                           input, output, omp_slices_cache);
+        break;
+      }
+    default:
+      assert(false); // unimplemented processor kind
+  }
+}
+
+//--------------------------------------------------------------------------
+void TaskBenchMapper::task_bench_slice_task(const Task &task,
+                                            const std::vector<Processor> &local,
+                                            const std::vector<Processor> &remote,
+                                            const SliceTaskInput& input,
+                                                  SliceTaskOutput &output,
+              std::map<Domain,std::vector<TaskSlice> > &cached_slices) const
+//--------------------------------------------------------------------------
+{
+  // Before we do anything else, see if it is in the cache
+  std::map<Domain,std::vector<TaskSlice> >::const_iterator finder =
+    cached_slices.find(input.domain);
+  if (finder != cached_slices.end()) {
+    output.slices = finder->second;
+    return;
+  }
+
+  // The two-level decomposition doesn't work so for now do a
+  // simple one-level decomposition across all the processors.
+  Machine::ProcessorQuery all_procs(machine);
+  all_procs.only_kind(local[0].kind());
+  if ((task.tag & SAME_ADDRESS_SPACE) != 0)
+	all_procs.local_address_space();
+  // Hack: This is a workaround for buggy code in the default mapper with DCR
+  std::vector<Processor> procs(local.begin(), local.end()); // (all_procs.begin(), all_procs.end());
+
+  switch (input.domain.get_dim())
+  {
+#define BLOCK(DIM) \
+    case DIM: \
+      { \
+        DomainT<DIM,coord_t> point_space = input.domain; \
+        Point<DIM,coord_t> num_blocks(procs.size()); \
+        default_decompose_points<DIM>(point_space, procs, \
+              num_blocks, false/*recurse*/, \
+              stealing_enabled, output.slices); \
+        break; \
+      }
+    LEGION_FOREACH_N(BLOCK)
+#undef BLOCK
+    default: // don't support other dimensions right now
+      assert(false);
+  }
+
+  // Save the result in the cache
+  cached_slices[input.domain] = output.slices;
 }
 
 static void create_mappers(Machine machine, Runtime *runtime, const std::set<Processor> &local_procs)
@@ -48,5 +347,8 @@ static void create_mappers(Machine machine, Runtime *runtime, const std::set<Pro
 
 void register_mappers()
 {
+  LinearShardingFunctor *sharding_functor = new LinearShardingFunctor();
+  Runtime::preregister_sharding_functor(SID_LINEAR, sharding_functor);
+
   Runtime::add_registration_callback(create_mappers);
 }

--- a/regent/mapper.cc
+++ b/regent/mapper.cc
@@ -31,29 +31,29 @@ public:
   LinearShardingFunctor();
   LinearShardingFunctor(const LinearShardingFunctor &rhs);
   virtual ~LinearShardingFunctor(void);
+
 public:
-  LinearShardingFunctor& operator=(const LinearShardingFunctor &rhs);
+  LinearShardingFunctor &operator=(const LinearShardingFunctor &rhs);
+
 public:
-  template<int DIM>
-  size_t linearize_point(const Realm::IndexSpace<DIM,coord_t> &is,
-                         const Realm::Point<DIM,coord_t> &point) const;
+  template <int DIM>
+  size_t linearize_point(const Realm::IndexSpace<DIM, coord_t> &is,
+                         const Realm::Point<DIM, coord_t> &point) const;
+
 public:
-  virtual ShardID shard(const DomainPoint &point,
-                        const Domain &full_space,
+  virtual ShardID shard(const DomainPoint &point, const Domain &full_space,
                         const size_t total_shards);
 };
 
 //--------------------------------------------------------------------------
-LinearShardingFunctor::LinearShardingFunctor()
-  : ShardingFunctor()
+LinearShardingFunctor::LinearShardingFunctor() : ShardingFunctor()
 //--------------------------------------------------------------------------
 {
 }
 
 //--------------------------------------------------------------------------
-LinearShardingFunctor::LinearShardingFunctor(
-                                           const LinearShardingFunctor &rhs)
-  : ShardingFunctor()
+LinearShardingFunctor::LinearShardingFunctor(const LinearShardingFunctor &rhs)
+    : ShardingFunctor()
 //--------------------------------------------------------------------------
 {
   // should never be called
@@ -67,8 +67,8 @@ LinearShardingFunctor::~LinearShardingFunctor(void)
 }
 
 //--------------------------------------------------------------------------
-LinearShardingFunctor& LinearShardingFunctor::operator=(
-                                           const LinearShardingFunctor &rhs)
+LinearShardingFunctor &LinearShardingFunctor::operator=(
+    const LinearShardingFunctor &rhs)
 //--------------------------------------------------------------------------
 {
   // should never be called
@@ -77,13 +77,13 @@ LinearShardingFunctor& LinearShardingFunctor::operator=(
 }
 
 //--------------------------------------------------------------------------
-template<int DIM>
+template <int DIM>
 size_t LinearShardingFunctor::linearize_point(
-                               const Realm::IndexSpace<DIM,coord_t> &is,
-                               const Realm::Point<DIM,coord_t> &point) const
+    const Realm::IndexSpace<DIM, coord_t> &is,
+    const Realm::Point<DIM, coord_t> &point) const
 //--------------------------------------------------------------------------
 {
-  Realm::AffineLinearizedIndexSpace<DIM,coord_t> linearizer(is);
+  Realm::AffineLinearizedIndexSpace<DIM, coord_t> linearizer(is);
   return linearizer.linearize(point);
 }
 
@@ -97,140 +97,124 @@ ShardID LinearShardingFunctor::shard(const DomainPoint &point,
   assert(point.get_dim() == full_space.get_dim());
 #endif
   size_t domain_size = full_space.get_volume();
-  switch (point.get_dim())
-  {
-    case 1:
-      {
-        const DomainT<1,coord_t> is = full_space;
-        const Point<1,coord_t> p1 = point;
-        return linearize_point<1>(is, p1)  * total_shards / domain_size;
-      }
-    case 2:
-      {
-        const DomainT<2,coord_t> is = full_space;
-        const Point<2,coord_t> p2 = point;
-        return linearize_point<2>(is, p2)  * total_shards / domain_size;
-      }
-    case 3:
-      {
-        const DomainT<3,coord_t> is = full_space;
-        const Point<3,coord_t> p3 = point;
-        return linearize_point<3>(is, p3)  * total_shards / domain_size;
-      }
-    default:
-      assert(false);
+  switch (point.get_dim()) {
+  case 1:
+    {
+      const DomainT<1, coord_t> is = full_space;
+      const Point<1, coord_t> p1 = point;
+      return linearize_point<1>(is, p1) * total_shards / domain_size;
+    }
+  case 2:
+    {
+      const DomainT<2, coord_t> is = full_space;
+      const Point<2, coord_t> p2 = point;
+      return linearize_point<2>(is, p2) * total_shards / domain_size;
+    }
+  case 3:
+    {
+      const DomainT<3, coord_t> is = full_space;
+      const Point<3, coord_t> p3 = point;
+      return linearize_point<3>(is, p3) * total_shards / domain_size;
+    }
+  default:
+    assert(false);
   }
   return 0;
 }
 
-class TaskBenchMapper : public DefaultMapper
-{
+class TaskBenchMapper : public DefaultMapper {
 public:
   TaskBenchMapper(MapperRuntime *rt, Machine machine, Processor local,
                   const char *mapper_name);
-  virtual void select_sharding_functor(
-                                 const MapperContext                ctx,
-                                 const Task&                        task,
-                                 const SelectShardingFunctorInput&  input,
-                                       SelectShardingFunctorOutput& output);
-  virtual void select_sharding_functor(
-                                 const MapperContext                ctx,
-                                 const Copy&                        copy,
-                                 const SelectShardingFunctorInput&  input,
-                                       SelectShardingFunctorOutput& output);
-  virtual void select_sharding_functor(
-                                 const MapperContext                ctx,
-                                 const Fill&                        fill,
-                                 const SelectShardingFunctorInput&  input,
-                                       SelectShardingFunctorOutput& output);
-  virtual void default_policy_select_target_processors(MapperContext ctx,
-                                                       const Task &task,
-                                                       std::vector<Processor> &target_procs);
-  virtual void slice_task(const MapperContext      ctx,
-                          const Task&              task,
-                          const SliceTaskInput&    input,
-                                SliceTaskOutput&   output);
-  void task_bench_slice_task(const Task &task,
-                             const std::vector<Processor> &local_procs,
-                             const std::vector<Processor> &remote_procs,
-                             const SliceTaskInput &input,
-                                   SliceTaskOutput &output,
-            std::map<Domain,std::vector<TaskSlice> > &cached_slices) const;
+  virtual void select_sharding_functor(const MapperContext ctx,
+                                       const Task &task,
+                                       const SelectShardingFunctorInput &input,
+                                       SelectShardingFunctorOutput &output);
+  virtual void select_sharding_functor(const MapperContext ctx,
+                                       const Copy &copy,
+                                       const SelectShardingFunctorInput &input,
+                                       SelectShardingFunctorOutput &output);
+  virtual void select_sharding_functor(const MapperContext ctx,
+                                       const Fill &fill,
+                                       const SelectShardingFunctorInput &input,
+                                       SelectShardingFunctorOutput &output);
+  virtual void default_policy_select_target_processors(
+      MapperContext ctx, const Task &task,
+      std::vector<Processor> &target_procs);
+  virtual void slice_task(const MapperContext ctx, const Task &task,
+                          const SliceTaskInput &input, SliceTaskOutput &output);
+  void task_bench_slice_task(
+      const Task &task, const std::vector<Processor> &local_procs,
+      const std::vector<Processor> &remote_procs, const SliceTaskInput &input,
+      SliceTaskOutput &output,
+      std::map<Domain, std::vector<TaskSlice> > &cached_slices) const;
 };
 
-TaskBenchMapper::TaskBenchMapper(MapperRuntime *rt, Machine machine, Processor local,
-                                 const char *mapper_name)
-  : DefaultMapper(rt, machine, local, mapper_name)
+TaskBenchMapper::TaskBenchMapper(MapperRuntime *rt, Machine machine,
+                                 Processor local, const char *mapper_name)
+    : DefaultMapper(rt, machine, local, mapper_name)
 {
 }
 
 void TaskBenchMapper::select_sharding_functor(
-                                 const MapperContext                ctx,
-                                 const Task&                        task,
-                                 const SelectShardingFunctorInput&  input,
-                                       SelectShardingFunctorOutput& output)
+    const MapperContext ctx, const Task &task,
+    const SelectShardingFunctorInput &input,
+    SelectShardingFunctorOutput &output)
 {
   output.chosen_functor = SID_LINEAR;
 }
 
 void TaskBenchMapper::select_sharding_functor(
-                                 const MapperContext                ctx,
-                                 const Copy&                        copy,
-                                 const SelectShardingFunctorInput&  input,
-                                       SelectShardingFunctorOutput& output)
+    const MapperContext ctx, const Copy &copy,
+    const SelectShardingFunctorInput &input,
+    SelectShardingFunctorOutput &output)
 {
   output.chosen_functor = SID_LINEAR;
 }
 
 void TaskBenchMapper::select_sharding_functor(
-                                 const MapperContext                ctx,
-                                 const Fill&                        fill,
-                                 const SelectShardingFunctorInput&  input,
-                                       SelectShardingFunctorOutput& output)
+    const MapperContext ctx, const Fill &fill,
+    const SelectShardingFunctorInput &input,
+    SelectShardingFunctorOutput &output)
 {
   output.chosen_functor = SID_LINEAR;
 }
 
-void TaskBenchMapper::default_policy_select_target_processors(MapperContext ctx,
-                                                              const Task &task,
-                                                              std::vector<Processor> &target_procs)
+void TaskBenchMapper::default_policy_select_target_processors(
+    MapperContext ctx, const Task &task, std::vector<Processor> &target_procs)
 {
   target_procs.push_back(task.target_proc);
 }
 
 //--------------------------------------------------------------------------
-void TaskBenchMapper::slice_task(const MapperContext      ctx,
-                                 const Task&              task,
-                                 const SliceTaskInput&    input,
-                                       SliceTaskOutput&   output)
+void TaskBenchMapper::slice_task(const MapperContext ctx, const Task &task,
+                                 const SliceTaskInput &input,
+                                 SliceTaskOutput &output)
 //--------------------------------------------------------------------------
 {
   std::vector<VariantID> variants;
   runtime->find_valid_variants(ctx, task.task_id, variants);
   /* find if we have a procset variant for task */
-  for(unsigned i = 0; i < variants.size(); i++)
-  {
+  for (unsigned i = 0; i < variants.size(); i++) {
     const ExecutionConstraintSet exset =
-       runtime->find_execution_constraints(ctx, task.task_id, variants[i]);
-    if(exset.processor_constraint.can_use(Processor::PROC_SET)) {
-
-       // Before we do anything else, see if it is in the cache
-       std::map<Domain,std::vector<TaskSlice> >::const_iterator finder =
-         procset_slices_cache.find(input.domain);
-       if (finder != procset_slices_cache.end()) {
-               output.slices = finder->second;
-               return;
-       }
+        runtime->find_execution_constraints(ctx, task.task_id, variants[i]);
+    if (exset.processor_constraint.can_use(Processor::PROC_SET)) {
+      // Before we do anything else, see if it is in the cache
+      std::map<Domain, std::vector<TaskSlice> >::const_iterator finder =
+          procset_slices_cache.find(input.domain);
+      if (finder != procset_slices_cache.end()) {
+        output.slices = finder->second;
+        return;
+      }
 
       output.slices.resize(input.domain.get_volume());
       unsigned idx = 0;
       Rect<1> rect = input.domain;
-      for (PointInRectIterator<1> pir(rect); pir(); pir++, idx++)
-      {
+      for (PointInRectIterator<1> pir(rect); pir(); pir++, idx++) {
         Rect<1> slice(*pir, *pir);
-        output.slices[idx] = TaskSlice(slice,
-          remote_procsets[idx % remote_cpus.size()],
-          false/*recurse*/, false/*stealable*/);
+        output.slices[idx] =
+            TaskSlice(slice, remote_procsets[idx % remote_cpus.size()],
+                      false /*recurse*/, false /*stealable*/);
       }
 
       // Save the result in the cache
@@ -242,62 +226,60 @@ void TaskBenchMapper::slice_task(const MapperContext      ctx,
   // Whatever kind of processor we are is the one this task should
   // be scheduled on as determined by select initial task
   Processor::Kind target_kind =
-    task.must_epoch_task ? local_proc.kind() : task.target_proc.kind();
-  switch (target_kind)
-  {
-    case Processor::LOC_PROC:
-      {
-        task_bench_slice_task(task, local_cpus, remote_cpus,
-                           input, output, cpu_slices_cache);
-        break;
-      }
-    case Processor::TOC_PROC:
-      {
-        task_bench_slice_task(task, local_gpus, remote_gpus,
-                           input, output, gpu_slices_cache);
-        break;
-      }
-    case Processor::IO_PROC:
-      {
-        task_bench_slice_task(task, local_ios, remote_ios,
-                           input, output, io_slices_cache);
-        break;
-      }
-    case Processor::PY_PROC:
-      {
-        task_bench_slice_task(task, local_pys, remote_pys,
-                           input, output, py_slices_cache);
-        break;
-      }
-    case Processor::PROC_SET:
-      {
-        task_bench_slice_task(task, local_procsets, remote_procsets,
-                           input, output, procset_slices_cache);
-        break;
-      }
-    case Processor::OMP_PROC:
-      {
-        task_bench_slice_task(task, local_omps, remote_omps,
-                           input, output, omp_slices_cache);
-        break;
-      }
-    default:
-      assert(false); // unimplemented processor kind
+      task.must_epoch_task ? local_proc.kind() : task.target_proc.kind();
+  switch (target_kind) {
+  case Processor::LOC_PROC:
+    {
+      task_bench_slice_task(task, local_cpus, remote_cpus, input, output,
+                            cpu_slices_cache);
+      break;
+    }
+  case Processor::TOC_PROC:
+    {
+      task_bench_slice_task(task, local_gpus, remote_gpus, input, output,
+                            gpu_slices_cache);
+      break;
+    }
+  case Processor::IO_PROC:
+    {
+      task_bench_slice_task(task, local_ios, remote_ios, input, output,
+                            io_slices_cache);
+      break;
+    }
+  case Processor::PY_PROC:
+    {
+      task_bench_slice_task(task, local_pys, remote_pys, input, output,
+                            py_slices_cache);
+      break;
+    }
+  case Processor::PROC_SET:
+    {
+      task_bench_slice_task(task, local_procsets, remote_procsets, input,
+                            output, procset_slices_cache);
+      break;
+    }
+  case Processor::OMP_PROC:
+    {
+      task_bench_slice_task(task, local_omps, remote_omps, input, output,
+                            omp_slices_cache);
+      break;
+    }
+  default:
+    assert(false);  // unimplemented processor kind
   }
 }
 
 //--------------------------------------------------------------------------
-void TaskBenchMapper::task_bench_slice_task(const Task &task,
-                                            const std::vector<Processor> &local,
-                                            const std::vector<Processor> &remote,
-                                            const SliceTaskInput& input,
-                                                  SliceTaskOutput &output,
-              std::map<Domain,std::vector<TaskSlice> > &cached_slices) const
+void TaskBenchMapper::task_bench_slice_task(
+    const Task &task, const std::vector<Processor> &local,
+    const std::vector<Processor> &remote, const SliceTaskInput &input,
+    SliceTaskOutput &output,
+    std::map<Domain, std::vector<TaskSlice> > &cached_slices) const
 //--------------------------------------------------------------------------
 {
   // Before we do anything else, see if it is in the cache
-  std::map<Domain,std::vector<TaskSlice> >::const_iterator finder =
-    cached_slices.find(input.domain);
+  std::map<Domain, std::vector<TaskSlice> >::const_iterator finder =
+      cached_slices.find(input.domain);
   if (finder != cached_slices.end()) {
     output.slices = finder->second;
     return;
@@ -307,40 +289,40 @@ void TaskBenchMapper::task_bench_slice_task(const Task &task,
   // simple one-level decomposition across all the processors.
   Machine::ProcessorQuery all_procs(machine);
   all_procs.only_kind(local[0].kind());
-  if ((task.tag & SAME_ADDRESS_SPACE) != 0)
-	all_procs.local_address_space();
+  if ((task.tag & SAME_ADDRESS_SPACE) != 0) all_procs.local_address_space();
   // Hack: This is a workaround for buggy code in the default mapper with DCR
-  std::vector<Processor> procs(local.begin(), local.end()); // (all_procs.begin(), all_procs.end());
+  std::vector<Processor> procs(
+      local.begin(), local.end());  // (all_procs.begin(), all_procs.end());
 
-  switch (input.domain.get_dim())
-  {
-#define BLOCK(DIM) \
-    case DIM: \
-      { \
-        DomainT<DIM,coord_t> point_space = input.domain; \
-        Point<DIM,coord_t> num_blocks(procs.size()); \
-        default_decompose_points<DIM>(point_space, procs, \
-              num_blocks, false/*recurse*/, \
-              stealing_enabled, output.slices); \
-        break; \
-      }
+  switch (input.domain.get_dim()) {
+#define BLOCK(DIM)                                                       \
+  case DIM:                                                              \
+    {                                                                    \
+      DomainT<DIM, coord_t> point_space = input.domain;                  \
+      Point<DIM, coord_t> num_blocks(procs.size());                      \
+      default_decompose_points<DIM>(point_space, procs, num_blocks,      \
+                                    false /*recurse*/, stealing_enabled, \
+                                    output.slices);                      \
+      break;                                                             \
+    }
     LEGION_FOREACH_N(BLOCK)
 #undef BLOCK
-    default: // don't support other dimensions right now
-      assert(false);
+  default:  // don't support other dimensions right now
+    assert(false);
   }
 
   // Save the result in the cache
   cached_slices[input.domain] = output.slices;
 }
 
-static void create_mappers(Machine machine, Runtime *runtime, const std::set<Processor> &local_procs)
+static void create_mappers(Machine machine, Runtime *runtime,
+                           const std::set<Processor> &local_procs)
 {
   for (std::set<Processor>::const_iterator it = local_procs.begin();
-        it != local_procs.end(); it++)
+       it != local_procs.end(); it++)
   {
-    TaskBenchMapper* mapper = new TaskBenchMapper(runtime->get_mapper_runtime(),
-                                              machine, *it, "task_bench_mapper");
+    TaskBenchMapper *mapper = new TaskBenchMapper(
+        runtime->get_mapper_runtime(), machine, *it, "task_bench_mapper");
     runtime->replace_default_mapper(mapper, *it);
   }
 }

--- a/regent/mapper.h
+++ b/regent/mapper.h
@@ -26,4 +26,4 @@ void register_mappers();
 }
 #endif
 
-#endif // __MAPPER_H__
+#endif  // __MAPPER_H__

--- a/test_all.sh
+++ b/test_all.sh
@@ -123,8 +123,8 @@ fi
 if [[ $USE_REGENT -eq 1 ]]; then
     for t in trivial no_comm stencil_1d stencil_1d_periodic nearest "spread -period 2" random_nearest all_to_all; do # FIXME: dom tree fft
         for k in "${kernels[@]}"; do
-            ./regent/main.shard15 -steps $steps -type $t $k -ll:io 1
-            ./regent/main.shard15 -steps $steps -type $t $k -ll:io 1 -ll:cpu 2
+            ./regent/task_bench -steps $steps -type $t $k -ll:io 1
+            ./regent/task_bench -steps $steps -type $t $k -ll:io 1 -ll:cpu 2
             # FIXME: Regent doesn't support multiple graphs
         done
     done


### PR DESCRIPTION
Remove old references to static control replication, which no longer exists as an optimization in Regent.

The Regent implementation now uses dynamic control replication, much like the Legion implementation, but at least it provides a different language implementation.