### PR TITLE
Switch to OpenMPI because MPICH has issues on Ubuntu 24.04

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -11,7 +11,10 @@ fi
 
 if [[ "$(uname)" = "Linux" ]]; then
   sudo apt-get update -qq
-  sudo apt-get install -qq mpich libmpich-dev libpcre3-dev binutils-dev
+  sudo apt-get install -qq openmpi-bin libopenmpi-dev libpcre3-dev binutils-dev
+  # To avoid error where OpenMPI doesn't think it has enough slots available.
+  export OMPI_MCA_rmaps_base_oversubscribe=yes
+  export OMPI_MCA_rmaps_base_mapping_policy="core:OVERSUBSCRIBE"
   if [[ $USE_CHAPEL -eq 1 ]]; then
     sudo apt-get install -qq clang-18 libclang-18-dev libclang-cpp18-dev llvm-18-dev libedit-dev libncurses5-dev zlib1g-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-18:/usr/share/llvm-18


### PR DESCRIPTION
This seems to be required to get a properly functioning StarPU, but it probably impacts everything else too.

On Ubuntu 24.04 MPICH seems to spawn ranks without them being aware that any other ranks exist, so the world size appears to be 1 no matter what the parameter to `mpirun -n` is.